### PR TITLE
Fix bug in overtime calculation

### DIFF
--- a/somenergia_custom/data/data.xml
+++ b/somenergia_custom/data/data.xml
@@ -174,5 +174,23 @@
             </field>
         </record>
 
+        <record model="ir.cron" id="som_fix_compute_overtime">
+            <field name="name">Som - Fix compute overtime</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">weeks</field>
+            <field name="numbercall">-1</field>
+            <field
+                name="nextcall"
+                eval="(DateTime.now() + timedelta(minutes=60)).strftime('%Y-%m-%d %H:05:00')"
+            />
+            <field name="doall" eval="False" />
+            <field name="active" eval="False" />
+            <field name="model_id" ref="somenergia_custom.model_hr_attendance_overtime" />
+            <field name="state">code</field>
+            <field name="code">
+                model._do_fix_compute_overtime()
+            </field>
+        </record>
+
     </data>
 </odoo>

--- a/somenergia_custom/data/data.xml
+++ b/somenergia_custom/data/data.xml
@@ -188,7 +188,7 @@
             <field name="model_id" ref="somenergia_custom.model_hr_attendance_overtime" />
             <field name="state">code</field>
             <field name="code">
-                model._do_fix_compute_overtime()
+                model._do_fix_compute_overtime(datetime.date.today())
             </field>
         </record>
 

--- a/somenergia_custom/models/hr_attendance_overtime.py
+++ b/somenergia_custom/models/hr_attendance_overtime.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
-
 from odoo import api, fields, models, tools, _
+from pathlib import Path
+from logging import getLogger
+import datetime
+import os
+
+_logger = getLogger(__name__)
 
 
 class HRAttendanceOvertime(models.Model):
@@ -28,3 +33,69 @@ class HRAttendanceOvertime(models.Model):
         }
 
         return action_open_attendances
+
+    def _get_weekdays_of_year_until_today(self):
+        # Get today's date
+        # TODO: change for real today when deploy to prod
+        today = datetime.date(2024, 9, 17) # datetime.date.today()
+
+        # Start on January 1st of the current year
+        start_date = datetime.date(today.year, 1, 1)
+
+        # Calculate the number of days from January 1st until today
+        days_until_today = (today - start_date).days + 1  # Adding 1 to include today
+
+        # Generate list of all weekdays (Monday to Friday)
+        weekdays = [
+            (start_date + datetime.timedelta(days=i)).isoformat()
+            for i in range(days_until_today)
+            if (start_date + datetime.timedelta(days=i)).weekday() < 5  # 0=Monday, ..., 4=Friday
+        ]
+
+        return weekdays
+
+    def _create_overtime_fixing_attendance(self, employee_id, str_day):
+        att_reason_id = self.env.ref("hr_attendance_reason.hr_act_reason_1")
+        comment = "Ajust dia no treballat"
+        att_id = self.env['hr.attendance'].create({
+            'employee_id': employee_id.id,
+            'check_in': str_day,
+            'check_out': str_day,
+            'attendance_reason_ids': [(4, att_reason_id.id)],
+            'som_comments': comment,
+        })
+        return att_id
+
+
+    def _do_fix_compute_overtime(self):
+        _logger.info("_do_fix_compute_overtime: start")
+        days_of_year_until_today = self._get_weekdays_of_year_until_today()
+        str_result = ''
+        for emp_id in self.env['hr.employee'].search([('id', 'not in', [275,156])], limit=2):
+            _logger.info("_do_fix_compute_overtime: checking employee '%s':" % emp_id.name)
+            att_ids = self.env['hr.attendance'].search([('employee_id', '=', emp_id.id)])
+            attendance_days_iso = [day.date().isoformat() for day in att_ids.mapped('check_in')]
+
+            overtime_ids = self.env['hr.attendance.overtime'].search([('employee_id', '=', emp_id.id)])
+            overtime_days_iso = [day.isoformat() for day in overtime_ids.mapped('date')]
+
+            list_days_to_check = attendance_days_iso + overtime_days_iso
+
+            days_to_check = [
+                day for day in days_of_year_until_today if day not in list_days_to_check
+            ]
+            for day in days_to_check:
+                # compute theoretical hours
+                th = self.env['hr.attendance.theoretical.time.report']._theoretical_hours(
+                    emp_id.sudo(), fields.Date.from_string(day)
+                )
+                if th > 0:
+                    str_result += "employee: %s | day: %s | th: %s \n" % (emp_id.name, day, str(th))
+                    fixing_att_id = self._create_overtime_fixing_attendance(emp_id, day)
+
+        path_odoo_module = Path(os.path.dirname(os.path.abspath(__file__))).parent
+        file = "files/overtime_check_%s.txt" % (datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
+        path_file_export = os.path.join(path_odoo_module, file)
+        with open(path_file_export, 'w') as file:
+            file.write(str_result)
+        _logger.info("_do_fix_compute_overtime: finish")

--- a/somenergia_custom/models/hr_attendance_overtime.py
+++ b/somenergia_custom/models/hr_attendance_overtime.py
@@ -33,24 +33,19 @@ class HRAttendanceOvertime(models.Model):
 
         return action_open_attendances
 
-    def _get_weekdays_of_year_until_today(self):
-        today = datetime.date.today()
-
-        # Start on January 1st of the current year
-        start_date = datetime.date(today.year, 1, 1)
-
-        # Calculate the number of days from January 1st until today
-        days_until_today = (today - start_date).days + 1  # Adding 1 to include today
-
+    @api.model
+    def _get_weekdays_of_year_until_date(self, date_to):
+        start_date = datetime.date(date_to.year, 1, 1)
+        days_until_date = (date_to - start_date).days + 1  # Adding 1 to include the date.day
         # Generate list of all weekdays (Monday to Friday)
         weekdays = [
             (start_date + datetime.timedelta(days=i)).isoformat()
-            for i in range(days_until_today)
+            for i in range(days_until_date)
             if (start_date + datetime.timedelta(days=i)).weekday() < 5  # 0=Monday, ..., 4=Friday
         ]
-
         return weekdays
 
+    @api.model
     def _create_overtime_fixing_attendance(self, employee_id, str_day):
         try:
             att_reason_id = self.env.ref("hr_attendance_reason.hr_act_reason_1")
@@ -67,6 +62,7 @@ class HRAttendanceOvertime(models.Model):
             _logger.info('Exception : %s ' % e)
             return False
 
+    @api.model
     def _write_file_result_fix_compute_overtime(self, str_result):
         path_odoo_module = Path(os.path.dirname(os.path.abspath(__file__))).parent
         file = "files/overtime_check_%s.txt" % (datetime.datetime.now().strftime("%Y%m%d_%H%M%S"))
@@ -74,23 +70,32 @@ class HRAttendanceOvertime(models.Model):
         with open(path_file_export, 'w') as file:
             file.write(str_result)
 
-    def _do_fix_compute_overtime(self):
+    @api.model
+    def _do_fix_compute_overtime(self, date_to = datetime.date.today()):
         _logger.info("_do_fix_compute_overtime: START")
-        days_of_year_until_today = self._get_weekdays_of_year_until_today()
+        days_of_year_until_date = self._get_weekdays_of_year_until_date(date_to)
         str_result = ''
         for emp_id in self.env['hr.employee'].search([('id', 'not in', [171,275,156])], limit=1000):
             _logger.info("_do_fix_compute_overtime: checking employee '%s':" % emp_id.name)
 
-            att_ids = self.env['hr.attendance'].search([('employee_id', '=', emp_id.id)])
+            att_ids = self.env['hr.attendance'].search([
+                ('employee_id', '=', emp_id.id),
+                ('check_out', '!=', False),
+                ('check_out', '<', fields.Date.to_string(date_to)),
+            ])
             attendance_days_iso = [day.date().isoformat() for day in att_ids.mapped('check_in')]
 
-            overtime_ids = self.env['hr.attendance.overtime'].search([('employee_id', '=', emp_id.id)])
+            overtime_ids = self.env['hr.attendance.overtime'].search([
+                ('employee_id', '=', emp_id.id),
+                ('date', '<=', fields.Date.to_string(date_to)),
+            ])
             overtime_days_iso = [day.isoformat() for day in overtime_ids.mapped('date')]
 
             list_days_to_check = list(set(attendance_days_iso + overtime_days_iso))
 
+            # we get week days without attendance or overtime record
             days_to_check = [
-                day for day in days_of_year_until_today if day not in list_days_to_check
+                day for day in days_of_year_until_date if day not in list_days_to_check
             ]
             for day in days_to_check:
                 # compute theoretical hours of the day
@@ -98,6 +103,8 @@ class HRAttendanceOvertime(models.Model):
                     emp_id.sudo(), fields.Date.from_string(day)
                 )
                 if th > 0:
+                    # we create a 0 worked hours attendance in the day,
+                    # and it forces to create overtime record properly
                     fixing_att_id = self._create_overtime_fixing_attendance(emp_id, day)
                     str_result += "employee: %s | day: %s | th: %s \n" % (emp_id.name, day, str(th))
 


### PR DESCRIPTION
Bug source: with no attendance on the day, the overtime hours calculation doesn't work properly for this day.

Developed a cron and related function to create in days with theoretical hours and no attendance, one attendance automatically with:
- 0 worked hours
- reason '_Manager Manual Amend_' 
- description comments  

This fixes the bug in overtime calculation, forcing the system to create the overtime register.