### PR TITLE
🐛 Show rich text toolbar in mail composer modal form

### DIFF
--- a/som_crm/__manifest__.py
+++ b/som_crm/__manifest__.py
@@ -29,6 +29,12 @@
     ],
     "external_dependencies": {"python": ["erppeek"]},
 
+    'assets': {
+        'web.assets_backend': [
+            '/som_crm/static/src/css/som_crm.css',
+        ],
+    },
+
     # always loaded
     'data': [
         'security/ir.model.access.csv',

--- a/som_crm/static/src/css/som_crm.css
+++ b/som_crm/static/src/css/som_crm.css
@@ -1,0 +1,4 @@
+/* Fix: wysiwyg floating toolbar hidden behind modal dialog */
+.o_web_client.modal-open .oe-toolbar.oe-floating {
+    z-index: 1060 !important;
+}


### PR DESCRIPTION
## Description
The wysiwyg floating toolbar was not visible when composing a mail message from a CRM lead modal dialog (Send message / Log note).
Root cause: the toolbar has z-index: 0 and was rendered behind the Bootstrap modal overlay (z-index: 1050), making it invisible despite being correctly positioned and functional.
Fix: elevate the toolbar z-index to 1060 (above the modal) when a modal is open.

<img width="1038" height="493" alt="image" src="https://github.com/user-attachments/assets/15d36c7e-7f56-474c-b43e-fe5cc2234348" />
