### PR TITLE
✨ Automate sending info email and stage change for leads in the initial stage

### DIFF
--- a/som_crm/__manifest__.py
+++ b/som_crm/__manifest__.py
@@ -49,6 +49,7 @@
         'views/mail_activity_views.xml',
         'views/phone_call_result_views.xml',
         'views/crm_phonecall_views.xml',
+        'views/mail_template_views.xml',
         'views/utm_menus.xml',
         'views/crm_stage_views.xml',
         'views/mail_message.xml',

--- a/som_crm/data/data.xml
+++ b/som_crm/data/data.xml
@@ -221,4 +221,33 @@
         </field>
     </record>
 
+    <record model="ir.cron" id="som_crm_lead_welcome_email">
+        <field name="name">Som - Send welcome email to new leads</field>
+        <field name="interval_number">1</field>
+        <field name="interval_type">hours</field>
+        <field name="numbercall">-1</field>
+        <field
+            name="nextcall"
+            eval="(DateTime.now() + timedelta(minutes=60)).strftime('%Y-%m-%d %H:05:00')"
+        />
+        <field name="doall" eval="True" />
+        <field name="active" eval="False" />
+        <field name="model_id" ref="som_crm.model_crm_lead" />
+        <field name="state">code</field>
+        <field name="code">
+            model._send_welcome_email_cron()
+        </field>
+    </record>
+    <record id="som_crm_action_send_welcome_email" model="ir.actions.server">
+        <field name="name">Som - Send welcome email</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="crm.model_crm_lead"/>
+        <field name="binding_model_id" ref="crm.model_crm_lead"/>
+        <field name="sequence">99</field>
+        <field name="state">code</field>
+        <field name="code">
+            records._send_welcome_email()
+        </field>
+    </record>
+
 </data>

--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -949,7 +949,7 @@ class Lead(models.Model):
             lead.duplicate_lead_count = len(duplicate_lead_ids)
 
     @api.model
-    def _send_welcome_email_cron(self):
+    def _send_welcome_email_cron(self, limit=50):
         _logger.info("Starting welcome email cron")
         origin_stage = self.env.ref('crm.stage_lead1', raise_if_not_found=False)
         if not origin_stage:
@@ -960,18 +960,20 @@ class Lead(models.Model):
             ('stage_id', '=', origin_stage.id),
             ('partner_id', '!=', False),
             ('email_from', '!=', False),
-        ], limit=2)
+        ], limit=limit)
         _logger.info(f"Leads found for welcome email: {len(leads)}")
         leads._send_welcome_email()
         _logger.info("Welcome email cron finished")
 
     def _send_welcome_email(self):
         company = self.env.company
-        template = company.som_crm_lead_welcome_template_id
+        template_ca = company.som_crm_lead_welcome_template_id
+        template_es = company.som_crm_lead_welcome_template_es_id
         target_stage = company.som_crm_lead_welcome_stage_id
         origin_stage = self.env.ref('crm.stage_lead1', raise_if_not_found=False)
+        lang_es = self.env.ref('base.lang_es', raise_if_not_found=False)
 
-        if not template or not target_stage or not origin_stage:
+        if not template_ca or not target_stage or not origin_stage:
             _logger.warning(
                 "Some configuration missing for welcome email. Skipping welcome email sending.",
             )
@@ -981,6 +983,9 @@ class Lead(models.Model):
             lambda x: x.stage_id == origin_stage and x.partner_id and x.email_from
         ):
             try:
+                lang = lead.partner_id.lang or ''
+                is_spanish = lang_es and lang == lang_es.code
+                template = template_es if (is_spanish and template_es) else template_ca
                 template.send_mail(lead.id, force_send=True)
                 lead.stage_id = target_stage
                 _logger.info(f"Welcome email sent and stage updated for lead ID {lead.id}")

--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -947,3 +947,42 @@ class Lead(models.Model):
 
             lead.duplicate_lead_ids = duplicate_lead_ids + lead
             lead.duplicate_lead_count = len(duplicate_lead_ids)
+
+    @api.model
+    def _send_welcome_email_cron(self):
+        _logger.info("Starting welcome email cron")
+        origin_stage = self.env.ref('crm.stage_lead1', raise_if_not_found=False)
+        if not origin_stage:
+            _logger.warning("Origin stage crm.stage_lead1 not found, skipping")
+            return
+
+        leads = self.search([
+            ('stage_id', '=', origin_stage.id),
+            ('partner_id', '!=', False),
+            ('email_from', '!=', False),
+        ], limit=2)
+        _logger.info(f"Leads found for welcome email: {len(leads)}")
+        leads._send_welcome_email()
+        _logger.info("Welcome email cron finished")
+
+    def _send_welcome_email(self):
+        company = self.env.company
+        template = company.som_crm_lead_welcome_template_id
+        target_stage = company.som_crm_lead_welcome_stage_id
+        origin_stage = self.env.ref('crm.stage_lead1', raise_if_not_found=False)
+
+        if not template or not target_stage or not origin_stage:
+            _logger.warning(
+                "Some configuration missing for welcome email. Skipping welcome email sending.",
+            )
+            return
+
+        for lead in self.filtered(
+            lambda x: x.stage_id == origin_stage and x.partner_id and x.email_from
+        ):
+            try:
+                template.send_mail(lead.id, force_send=True)
+                lead.stage_id = target_stage
+                _logger.info(f"Welcome email sent and stage updated for lead ID {lead.id}")
+            except Exception as e:
+                _logger.error(f"Error sending welcome email for lead ID {lead.id}: {e}")

--- a/som_crm/models/res_company.py
+++ b/som_crm/models/res_company.py
@@ -26,3 +26,14 @@ class ResCompany(models.Model):
     som_ff_auto_upcomming_activity = fields.Boolean(
         string="Automatic Upcoming Activity creation on Lead creation",
     )
+
+    som_crm_lead_welcome_template_id = fields.Many2one(
+        string="Lead Welcome Email Template",
+        comodel_name="mail.template",
+        domain="[('model', '=', 'crm.lead')]",
+    )
+
+    som_crm_lead_welcome_stage_id = fields.Many2one(
+        string="Lead Welcome Target Stage",
+        comodel_name="crm.stage",
+    )

--- a/som_crm/models/res_company.py
+++ b/som_crm/models/res_company.py
@@ -28,7 +28,13 @@ class ResCompany(models.Model):
     )
 
     som_crm_lead_welcome_template_id = fields.Many2one(
-        string="Lead Welcome Email Template",
+        string="Lead Welcome Email Template (CA)",
+        comodel_name="mail.template",
+        domain="[('model', '=', 'crm.lead')]",
+    )
+
+    som_crm_lead_welcome_template_es_id = fields.Many2one(
+        string="Lead Welcome Email Template (ES)",
         comodel_name="mail.template",
         domain="[('model', '=', 'crm.lead')]",
     )

--- a/som_crm/models/res_config_settings.py
+++ b/som_crm/models/res_config_settings.py
@@ -41,6 +41,11 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
     )
 
+    som_crm_lead_welcome_template_es_id = fields.Many2one(
+        related='company_id.som_crm_lead_welcome_template_es_id',
+        readonly=False,
+    )
+
     som_crm_lead_welcome_stage_id = fields.Many2one(
         related='company_id.som_crm_lead_welcome_stage_id',
         readonly=False,

--- a/som_crm/models/res_config_settings.py
+++ b/som_crm/models/res_config_settings.py
@@ -35,3 +35,13 @@ class ResConfigSettings(models.TransientModel):
         config_parameter='som_crm_daily_won_leads_target',
         default=0
     )
+
+    som_crm_lead_welcome_template_id = fields.Many2one(
+        related='company_id.som_crm_lead_welcome_template_id',
+        readonly=False,
+    )
+
+    som_crm_lead_welcome_stage_id = fields.Many2one(
+        related='company_id.som_crm_lead_welcome_stage_id',
+        readonly=False,
+    )

--- a/som_crm/tests/__init__.py
+++ b/som_crm/tests/__init__.py
@@ -7,4 +7,5 @@ from . import test_crm_lead
 from . import test_crm_phonecall
 from . import test_crm_lead_sync
 from . import test_crm_team
+from . import test_crm_lead_welcome_email
 from . import test_som_crm_mail_domain_blacklist

--- a/som_crm/tests/test_crm_lead_welcome_email.py
+++ b/som_crm/tests/test_crm_lead_welcome_email.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+from unittest.mock import patch
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('som_welcome_email')
+class TestSendWelcomeEmail(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.origin_stage = cls.env.ref('crm.stage_lead1')
+        cls.target_stage = cls.env['crm.stage'].create({'name': 'Welcome Sent'})
+
+        cls.lang_ca = cls.env.ref('base.lang_ca_ES', raise_if_not_found=False)
+        cls.lang_es = cls.env.ref('base.lang_es', raise_if_not_found=False)
+
+        cls.partner_ca = cls.env['res.partner'].create({
+            'name': 'Partner CA',
+            'email': 'partner.ca@example.com',
+            'lang': cls.lang_ca.code if cls.lang_ca else 'ca_ES',
+        })
+        cls.partner_es = cls.env['res.partner'].create({
+            'name': 'Partner ES',
+            'email': 'partner.es@example.com',
+            'lang': cls.lang_es.code if cls.lang_es else 'es_ES',
+        })
+        cls.partner_no_email = cls.env['res.partner'].create({
+            'name': 'Partner No Email',
+        })
+
+        cls.template_ca = cls.env['mail.template'].create({
+            'name': 'Welcome CA',
+            'model_id': cls.env['ir.model']._get('crm.lead').id,
+            'subject': 'Benvinguda',
+            'body_html': '<p>Hola</p>',
+        })
+        cls.template_es = cls.env['mail.template'].create({
+            'name': 'Welcome ES',
+            'model_id': cls.env['ir.model']._get('crm.lead').id,
+            'subject': 'Bienvenida',
+            'body_html': '<p>Hola</p>',
+        })
+
+        cls.env.company.som_crm_lead_welcome_template_id = cls.template_ca
+        cls.env.company.som_crm_lead_welcome_template_es_id = cls.template_es
+        cls.env.company.som_crm_lead_welcome_stage_id = cls.target_stage
+
+    def _create_lead(self, partner, stage=None):
+        return self.env['crm.lead'].create({
+            'name': f'Lead {partner.name}',
+            'partner_id': partner.id,
+            'email_from': partner.email,
+            'stage_id': (stage or self.origin_stage).id,
+        })
+
+    # --- _send_welcome_email ---
+
+    def test_ca_partner_uses_ca_template(self):
+        lead = self._create_lead(self.partner_ca)
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_called_once_with(lead.id, force_send=True)
+        self.assertEqual(lead.stage_id, self.target_stage)
+
+    def test_es_partner_uses_es_template(self):
+        lead = self._create_lead(self.partner_es)
+        with patch.object(type(self.template_es), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_called_once_with(lead.id, force_send=True)
+        self.assertEqual(lead.stage_id, self.target_stage)
+
+    def test_es_partner_falls_back_to_ca_if_no_es_template(self):
+        self.env.company.som_crm_lead_welcome_template_es_id = False
+        lead = self._create_lead(self.partner_es)
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_called_once_with(lead.id, force_send=True)
+        self.assertEqual(lead.stage_id, self.target_stage)
+        # restore
+        self.env.company.som_crm_lead_welcome_template_es_id = self.template_es
+
+    def test_skips_lead_without_partner(self):
+        lead = self._create_lead(self.partner_ca)
+        lead.partner_id = False
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_not_called()
+        self.assertEqual(lead.stage_id, self.origin_stage)
+
+    def test_skips_lead_without_email(self):
+        lead = self._create_lead(self.partner_no_email)
+        lead.email_from = False
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_not_called()
+        self.assertEqual(lead.stage_id, self.origin_stage)
+
+    def test_skips_lead_in_wrong_stage(self):
+        lead = self._create_lead(self.partner_ca, stage=self.target_stage)
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_not_called()
+        self.assertEqual(lead.stage_id, self.target_stage)
+
+    def test_skips_all_if_no_template_ca(self):
+        self.env.company.som_crm_lead_welcome_template_id = False
+        lead = self._create_lead(self.partner_ca)
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_not_called()
+        # restore
+        self.env.company.som_crm_lead_welcome_template_id = self.template_ca
+
+    def test_skips_all_if_no_target_stage(self):
+        self.env.company.som_crm_lead_welcome_stage_id = False
+        lead = self._create_lead(self.partner_ca)
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._send_welcome_email()
+            mock_send.assert_not_called()
+        # restore
+        self.env.company.som_crm_lead_welcome_stage_id = self.target_stage
+
+    def test_continues_after_error_on_one_lead(self):
+        lead_ca = self._create_lead(self.partner_ca)
+        lead_es = self._create_lead(self.partner_es)
+
+        def mock_send(lead_id, force_send):
+            if lead_id == lead_ca.id:
+                raise Exception("SMTP error")
+
+        with patch.object(type(self.template_ca), 'send_mail', side_effect=mock_send), \
+             patch.object(type(self.template_es), 'send_mail', side_effect=mock_send):
+            (lead_ca | lead_es)._send_welcome_email()
+
+        self.assertEqual(lead_ca.stage_id, self.origin_stage)
+        self.assertEqual(lead_es.stage_id, self.target_stage)
+        self.assertEqual(lead_ca.stage_id, self.origin_stage)
+        self.assertEqual(lead_es.stage_id, self.target_stage)
+
+    # --- _send_welcome_email_cron ---
+
+    def test_cron_finds_eligible_leads(self):
+        lead = self._create_lead(self.partner_ca)
+        with patch.object(type(self.template_ca), 'send_mail'):
+            self.env['crm.lead']._send_welcome_email_cron()
+        self.assertEqual(lead.stage_id, self.target_stage)

--- a/som_crm/views/mail_template_views.xml
+++ b/som_crm/views/mail_template_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="som_action_email_template_crm" model="ir.actions.act_window">
+        <field name="name">Plantilles de correu CRM</field>
+        <field name="res_model">mail.template</field>
+        <field name="view_mode">list,form</field>
+        <field name="domain">[('model', '=', 'crm.lead')]</field>
+        <field name="context">{'default_model': 'crm.lead'}</field>
+    </record>
+
+    <menuitem id="som_menu_email_templates"
+        action="som_crm.som_action_email_template_crm"
+        parent="crm.crm_menu_config"
+        sequence="50"
+        groups="mail.group_mail_template_editor"/>
+</odoo>

--- a/som_crm/views/res_config_settings_views.xml
+++ b/som_crm/views/res_config_settings_views.xml
@@ -71,9 +71,16 @@
                 <div class="col-12 col-lg-6 o_setting_box">
                     <div class="o_setting_right_pane">
                         <label for="som_crm_lead_welcome_template_id"/>
-                        <div class="text-muted">Plantilla de benvinguda per a leads nous</div>
+                        <div class="text-muted">Plantilla de benvinguda per a leads nous (CA)</div>
                         <div class="content-group mt16">
                             <field name="som_crm_lead_welcome_template_id" class="o_light_label"/>
+                        </div>
+                        <div class="mt8">
+                        <label for="som_crm_lead_welcome_template_es_id"/>
+                        <div class="text-muted">Plantilla de benvinguda per a leads nous (ES)</div>
+                        </div>
+                        <div class="content-group mt8">
+                            <field name="som_crm_lead_welcome_template_es_id" class="o_light_label"/>
                         </div>
                         <div class="mt8">
                         <label for="som_crm_lead_welcome_stage_id"/>

--- a/som_crm/views/res_config_settings_views.xml
+++ b/som_crm/views/res_config_settings_views.xml
@@ -68,6 +68,23 @@
                     </div>
                 </div>
 
+                <div class="col-12 col-lg-6 o_setting_box">
+                    <div class="o_setting_right_pane">
+                        <label for="som_crm_lead_welcome_template_id"/>
+                        <div class="text-muted">Plantilla de benvinguda per a leads nous</div>
+                        <div class="content-group mt16">
+                            <field name="som_crm_lead_welcome_template_id" class="o_light_label"/>
+                        </div>
+                        <div class="mt8">
+                        <label for="som_crm_lead_welcome_stage_id"/>
+                        <div class="text-muted">Etapa destí després d'enviar la benvinguda</div>
+                        </div>
+                        <div class="content-group mt8">
+                            <field name="som_crm_lead_welcome_stage_id" class="o_light_label"/>
+                        </div>
+                    </div>
+                </div>
+
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Description
When a new lead arrives at the initial stage, the system can now automatically send a welcome email and move it to the next stage.                                                                                                                        
                                                                                                                                                                                      
The email template and target stage are configurable from the CRM settings, with separate templates for Catalan and Spanish — falling  back to Catalan by default. The process runs via a scheduled cron job  and can also be triggered manually by selecting leads from the list view.                                                                                                                
                                                                                                                                                                                      
Template editors can now manage CRM email templates directly from  CRM > Configuration, without needing admin access to the technical menu.

https://somenergia.openproject.com/wp/1452

