### PR TITLE
FIX_lead_absence_filter

### DIFF
--- a/som_crm/models/crm_team.py
+++ b/som_crm/models/crm_team.py
@@ -24,7 +24,14 @@ class CrmTeam(models.Model):
         if exclude_team_leader:
             user_member_ids = user_member_ids.filtered(lambda x: x != self.user_id)
         if exclude_absent_members:
-            user_member_ids = user_member_ids.filtered(lambda x: x.employee_id.is_present)
+            absent_today_employee_ids = set(self.env['hr.leave'].sudo().search([
+                ('employee_id', 'in', user_member_ids.mapped('employee_id').ids),
+                ('request_date_from', '<=', today),
+                ('request_date_to', '>=', today),
+            ]).mapped('employee_id').ids)
+            user_member_ids = user_member_ids.filtered(
+                lambda x: x.employee_id and x.employee_id.id not in absent_today_employee_ids
+            )
         user_member_ids = user_member_ids.filtered(_can_be_assigned_opportunities)
         user_member_with_capacity_ids = user_member_ids.filtered(
             lambda x: x._get_available_leads_capacity() > 0

--- a/som_crm/tests/test_crm_team.py
+++ b/som_crm/tests/test_crm_team.py
@@ -100,6 +100,8 @@ class TestCrmTeam(TransactionCase):
             'holiday_status_id': cls.hr_leave_type_1.id,
             'date_from': leave_start_datetime,
             'date_to': leave_end_datetime,
+            'request_date_from': date(2025, 4, 1),
+            'request_date_to': date(2025, 4, 3),
             'number_of_days': 3,
         })
 
@@ -224,6 +226,52 @@ class TestCrmTeam(TransactionCase):
                          "Member 1 (absent) should NOT be in the candidate list.")
         self.assertIn(self.user_member_2, called_list,
                       "Member 2 should be in the candidate list.")
+
+    @freeze_time('2025-04-04 12:00:00')
+    @patch('odoo.addons.som_crm.models.crm_team.choice')
+    def test_team_exclude_member_absent_same_day_with_time_gap(self, mock_choice):
+        """A member with two leaves in same day must be excluded all day."""
+        morning_start = datetime(2025, 4, 4, 8, 0, 0)
+        morning_end = datetime(2025, 4, 4, 10, 0, 0)
+        evening_start = datetime(2025, 4, 4, 14, 0, 0)
+        evening_end = datetime(2025, 4, 4, 16, 0, 0)
+
+        self.env['hr.leave'].with_context(
+            mail_create_nolog=True, mail_notrack=True
+        ).with_user(self.user_member_2).create({
+            'name': 'Leave 2 morning',
+            'employee_id': self.user_member_2.employee_id.id,
+            'holiday_status_id': self.hr_leave_type_1.id,
+            'date_from': morning_start,
+            'date_to': morning_end,
+            'request_date_from': date(2025, 4, 4),
+            'request_date_to': date(2025, 4, 4),
+            'number_of_days': 1,
+        })
+        self.env['hr.leave'].with_context(
+            mail_create_nolog=True, mail_notrack=True
+        ).with_user(self.user_member_2).create({
+            'name': 'Leave 2 evening',
+            'employee_id': self.user_member_2.employee_id.id,
+            'holiday_status_id': self.hr_leave_type_1.id,
+            'date_from': evening_start,
+            'date_to': evening_end,
+            'request_date_from': date(2025, 4, 4),
+            'request_date_to': date(2025, 4, 4),
+            'number_of_days': 1,
+        })
+
+        mock_choice.return_value = self.user_leader
+        member = self.team_full.get_random_member(exclude_absent_members=True)
+
+        self.assertEqual(member, self.user_leader)
+        mock_choice.assert_called_once()
+        called_list = mock_choice.call_args[0][0]
+
+        self.assertNotIn(self.user_member_2, called_list,
+                         "Member 2 should be excluded for whole day.")
+        self.assertIn(self.user_leader, called_list)
+        self.assertIn(self.user_member_1, called_list)
 
     def test_team_members_capacity(self):
         """


### PR DESCRIPTION
## Objectiu

Evitar l'assignació de leads a membres de l'equip que tinguin una absència en el dia actual, encara que en aquell moment concret no estiguin absents per franja horària.

## Targeta on es demana o Incidència

No s'ha facilitat cap targeta ni incidència vinculada per aquesta tasca.

## Comportament antic

El filtre d'assignació feia servir `employee_id.is_present`, que depèn de l'hora actual. Això podia assignar leads en franges entre absències concatenades dins del mateix dia.

## Comportament nou

L'assignació de leads exclou membres amb absències que solapin el dia actual (`request_date_from`/`request_date_to`), independentment de l'hora actual.

## Comprovacions

- [ ] Hi ha testos
- [ ] Reiniciar serveis
- [ ] Actualitzar mòdul
- [ ] Script de migració
- [ ] Modifica traduccions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop assigning leads to team members with any leave overlapping today, regardless of time. Replaces the time-dependent `employee_id.is_present` check with a request date filter on `hr.leave`; adds tests for day-level exclusion.

- **Bug Fixes**
  - Excludes members with `hr.leave` where `request_date_from` <= today <= `request_date_to`.
  - Prevents lead assignment in gaps between contiguous same-day absences.

- **Tests**
  - Adds tests ensuring two leaves on the same day still exclude the member all day.

<sup>Written for commit e08bcfc8e19edc044dc5393c7dc7196695ab2ee0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

