### PR TITLE
IMP Prevent phone-only partner match when emails differ

### DIFF
--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -497,7 +497,7 @@ class Lead(models.Model):
         if not partner and self.phone:
             candidate = self.env['res.partner'].search([('phone', '=', self.phone)], limit=1)
             if candidate and candidate.email and self.email_from \
-                    and candidate.email != self.email_from:
+                    and candidate.email.lower() != self.email_from.lower():
                 candidate = self.env['res.partner']
             partner = candidate
 

--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -495,7 +495,11 @@ class Lead(models.Model):
             partner = self.env['res.partner'].search([('email', '=', self.email_from)], limit=1)
 
         if not partner and self.phone:
-            partner = self.env['res.partner'].search([('phone', '=', self.phone)], limit=1)
+            candidate = self.env['res.partner'].search([('phone', '=', self.phone)], limit=1)
+            if candidate and candidate.email and self.email_from \
+                    and candidate.email != self.email_from:
+                candidate = self.env['res.partner']
+            partner = candidate
 
         return partner
 

--- a/som_crm/tests/__init__.py
+++ b/som_crm/tests/__init__.py
@@ -9,3 +9,4 @@ from . import test_crm_lead_sync
 from . import test_crm_team
 from . import test_crm_lead_welcome_email
 from . import test_som_crm_mail_domain_blacklist
+from . import test_find_matching_partner

--- a/som_crm/tests/test_find_matching_partner.py
+++ b/som_crm/tests/test_find_matching_partner.py
@@ -1,0 +1,65 @@
+# -*- coding: utf-8 -*-
+
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('som_find_matching_partner')
+class TestFindMatchingPartner(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.partner_with_email = cls.env['res.partner'].create({
+            'name': 'Partner With Email',
+            'email': 'existing@example.com',
+            'phone': '600000000',
+        })
+        cls.partner_without_email = cls.env['res.partner'].create({
+            'name': 'Partner Without Email',
+            'phone': '611111111',
+        })
+
+    def _create_lead(self, phone=False, email_from=False):
+        vals = {
+            'name': 'Test Lead',
+            'type': 'opportunity',
+        }
+        if phone:
+            vals['phone'] = phone
+        if email_from:
+            vals['email_from'] = email_from
+        return self.env['crm.lead'].create(vals)
+
+    def test_match_by_email(self):
+        """Lead with matching email finds partner by email."""
+        lead = self._create_lead(email_from='existing@example.com')
+        partner = lead._find_matching_partner_custom()
+        self.assertEqual(partner, self.partner_with_email)
+
+    def test_match_by_phone_no_emails(self):
+        """Lead without email, partner without email: match by phone."""
+        lead = self._create_lead(phone='611111111')
+        partner = lead._find_matching_partner_custom()
+        self.assertEqual(partner, self.partner_without_email)
+
+    def test_match_by_phone_same_email(self):
+        """Lead with same phone and same email as partner: match."""
+        lead = self._create_lead(phone='600000000', email_from='existing@example.com')
+        partner = lead._find_matching_partner_custom()
+        self.assertEqual(partner, self.partner_with_email)
+
+    def test_no_match_by_phone_different_email(self):
+        """
+        Lead with a fake phone (e.g. 600000000) and a different email than the matched partner:
+        no match is returned to avoid assigning the wrong contact.
+        """
+        lead = self._create_lead(phone='600000000', email_from='other@example.com')
+        partner = lead._find_matching_partner_custom()
+        self.assertFalse(partner)
+
+    def test_no_match_no_data(self):
+        """Lead without email or phone: no match."""
+        lead = self._create_lead()
+        partner = lead._find_matching_partner_custom()
+        self.assertFalse(partner)

--- a/som_crm/tests/test_find_matching_partner.py
+++ b/som_crm/tests/test_find_matching_partner.py
@@ -63,3 +63,9 @@ class TestFindMatchingPartner(TransactionCase):
         lead = self._create_lead()
         partner = lead._find_matching_partner_custom()
         self.assertFalse(partner)
+
+    def test_match_by_phone_partner_no_email_lead_has_email(self):
+        """Phone match: partner has no email but lead does — match proceeds."""
+        lead = self._create_lead(phone='611111111', email_from='newperson@example.com')
+        partner = lead._find_matching_partner_custom()
+        self.assertEqual(partner, self.partner_without_email)


### PR DESCRIPTION
## Description
Stop phone-only partner matches when lead and partner emails conflict to avoid assigning the wrong contact. Adds an email check to `_find_matching_partner_custom` and tests to cover the new behavior.

https://freescout.somenergia.coop/conversation/8158838?folder_id=185



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent phone-only partner matches when lead and partner emails conflict to avoid assigning the wrong contact. Adds a case-insensitive email check to `_find_matching_partner_custom` and tests for the new behavior.

- **Bug Fixes**
  - Compare emails case-insensitively before accepting a phone match; if both exist and differ, return no match.
  - Keep phone match when emails match or when one side has no email. Tests cover email match, no emails, same email+phone, different email+phone (no match), no data (no match), and partner-without-email + lead-with-email (match).

<sup>Written for commit 40c0e8cb1f69901139269daa511048b22367bb63. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



