### PR TITLE
💄 Make partner visible in kanban project task view

### DIFF
--- a/somenergia_custom/views/project_task_view.xml
+++ b/somenergia_custom/views/project_task_view.xml
@@ -18,11 +18,6 @@
                     <attribute name="readonly">1</attribute>
                     <attribute name="force_save">1</attribute>
                 </xpath>
-                <xpath expr="//field[@name='partner_id']" position="attributes">
-                    <attribute name="attrs">
-                        {'invisible': 1}
-                    </attribute>
-                </xpath>
                 <xpath expr="//field[@name='tag_ids']" position="attributes">
                     <attribute name="domain">
                         [('som_for_internal_project', '=', False)]


### PR DESCRIPTION
## Description
Make partner visible in kanban project task view




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the partner visible on Project Task Kanban cards so users can see the related partner at a glance.
Removes the `{'invisible': 1}` attribute from `partner_id` in `project_task_view.xml`.

<sup>Written for commit f33f4753457ca79b5daef8e3c6223e16b180cd9a. Summary will update on new commits. <a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/84?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

