### PR TITLE
✨ feat(project): add som_hide_partner flag to hide partner on tasks

### DIFF
--- a/somenergia_custom/models/project.py
+++ b/somenergia_custom/models/project.py
@@ -31,6 +31,11 @@ class Project(models.Model):
         store=True,
     )
 
+    som_hide_partner = fields.Boolean(
+        string='Hide partner on tasks',
+        default=True,
+    )
+
     def _load_default_tasks(self):
         user_somadmin_id = self.env['res.users'].search([
             ('login', '=', 'somadmin@somenergia.coop'),

--- a/somenergia_custom/models/project_task.py
+++ b/somenergia_custom/models/project_task.py
@@ -24,6 +24,12 @@ class Task(models.Model):
         string="Transversal project"
     )
 
+    som_hide_partner = fields.Boolean(
+        related='project_id.som_hide_partner',
+        string='Hide partner',
+        store=False,
+    )
+
     def name_get(self):
         res = []
         for task_id in self:

--- a/somenergia_custom/views/project_task_view.xml
+++ b/somenergia_custom/views/project_task_view.xml
@@ -13,6 +13,11 @@
                            invisible="1"/>
                     <field name="kanban_state"
                            invisible="1"/>
+                    <field name="som_hide_partner"
+                           invisible="1"/>
+                </xpath>
+                <xpath expr="//field[@name='partner_id']" position="attributes">
+                    <attribute name="attrs">{'invisible': [('som_hide_partner', '=', True)]}</attribute>
                 </xpath>
                 <xpath expr="//field[@name='project_id']" position="attributes">
                     <attribute name="readonly">1</attribute>

--- a/somenergia_custom/views/project_view.xml
+++ b/somenergia_custom/views/project_view.xml
@@ -1,6 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data>
+        <record id="som_project_view_form_inherit" model="ir.ui.view">
+            <field name="model">project.project</field>
+            <field name="inherit_id" ref="project.edit_project"/>
+            <field name="arch" type="xml">
+                <xpath expr="//page[@name='settings']//group[@name='extra_settings']" position="inside">
+                    <field name="som_hide_partner" widget="boolean_toggle"/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="project.open_view_project_all" model="ir.actions.act_window">
             <field name="domain">[('is_internal_project', '=', False), ('som_is_internal_project', '=', False)]</field>
         </record>


### PR DESCRIPTION
## Description
https://somenergia.openproject.com/wp/1734



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a project-level `som_hide_partner` flag to control visibility of the task partner field. It defaults to on and can be toggled in Project Settings.

- **New Features**
  - Project: new `som_hide_partner` (default True) with a boolean toggle in Extra settings.
  - Tasks: related `som_hide_partner` field; hides `partner_id` when the flag is enabled.

<sup>Written for commit b0ee99465fe87129e23ecc553258ec1f7931f4e3. Summary will update on new commits. <a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/85?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

