### PR TITLE
feat(som_crm): close open activities when processing lead welcome flow

### DIFF
--- a/som_crm/data/data.xml
+++ b/som_crm/data/data.xml
@@ -257,8 +257,8 @@
         </field>
     </record>
 
-    <record model="ir.cron" id="som_crm_lead_welcome_email">
-        <field name="name">Som - Send welcome email to new leads</field>
+    <record model="ir.cron" id="som_crm_lead_process_welcome">
+        <field name="name">Som - Process welcome for new leads</field>
         <field name="interval_number">1</field>
         <field name="interval_type">hours</field>
         <field name="numbercall">-1</field>
@@ -271,18 +271,21 @@
         <field name="model_id" ref="som_crm.model_crm_lead" />
         <field name="state">code</field>
         <field name="code">
-            model._send_welcome_email_cron()
+            model._process_welcome_cron()
         </field>
     </record>
-    <record id="som_crm_action_send_welcome_email" model="ir.actions.server">
-        <field name="name">Som - Send welcome email</field>
+    <record model="ir.cron" id="som_crm_lead_welcome_email">
+        <field name="active" eval="False" />
+    </record>
+    <record id="som_crm_action_process_welcome" model="ir.actions.server">
+        <field name="name">Som - Process welcome</field>
         <field name="type">ir.actions.server</field>
         <field name="model_id" ref="crm.model_crm_lead"/>
         <field name="binding_model_id" ref="crm.model_crm_lead"/>
         <field name="sequence">99</field>
         <field name="state">code</field>
         <field name="code">
-            records._send_welcome_email()
+            records._process_welcome()
         </field>
     </record>
 

--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -1206,7 +1206,7 @@ class Lead(models.Model):
             lead.duplicate_lead_count = len(duplicate_lead_ids)
 
     @api.model
-    def _send_welcome_email_cron(self, limit=50):
+    def _process_welcome_cron(self, limit=50):
         _logger.info("Starting welcome email cron")
         origin_stage = self.env.ref('crm.stage_lead1', raise_if_not_found=False)
         if not origin_stage:
@@ -1219,10 +1219,10 @@ class Lead(models.Model):
             ('email_from', '!=', False),
         ], limit=limit)
         _logger.info(f"Leads found for welcome email: {len(leads)}")
-        leads._send_welcome_email()
+        leads._process_welcome()
         _logger.info("Welcome email cron finished")
 
-    def _send_welcome_email(self):
+    def _process_welcome(self):
         company = self.env.company
         template_ca = company.som_crm_lead_welcome_template_id
         template_es = company.som_crm_lead_welcome_template_es_id
@@ -1244,6 +1244,7 @@ class Lead(models.Model):
                 is_spanish = lang_es and lang == lang_es.code
                 template = template_es if (is_spanish and template_es) else template_ca
                 template.send_mail(lead.id, force_send=True)
+                lead.activity_ids.unlink()
                 lead.stage_id = target_stage
                 _logger.info(f"Welcome email sent and stage updated for lead ID {lead.id}")
             except Exception as e:

--- a/som_crm/tests/test_crm_lead_welcome_email.py
+++ b/som_crm/tests/test_crm_lead_welcome_email.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from datetime import date
 from unittest.mock import patch
 from odoo.tests.common import TransactionCase, tagged
 
@@ -55,19 +56,19 @@ class TestSendWelcomeEmail(TransactionCase):
             'stage_id': (stage or self.origin_stage).id,
         })
 
-    # --- _send_welcome_email ---
+    # --- _process_welcome ---
 
     def test_ca_partner_uses_ca_template(self):
         lead = self._create_lead(self.partner_ca)
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_called_once_with(lead.id, force_send=True)
         self.assertEqual(lead.stage_id, self.target_stage)
 
     def test_es_partner_uses_es_template(self):
         lead = self._create_lead(self.partner_es)
         with patch.object(type(self.template_es), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_called_once_with(lead.id, force_send=True)
         self.assertEqual(lead.stage_id, self.target_stage)
 
@@ -75,7 +76,7 @@ class TestSendWelcomeEmail(TransactionCase):
         self.env.company.som_crm_lead_welcome_template_es_id = False
         lead = self._create_lead(self.partner_es)
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_called_once_with(lead.id, force_send=True)
         self.assertEqual(lead.stage_id, self.target_stage)
         # restore
@@ -85,7 +86,7 @@ class TestSendWelcomeEmail(TransactionCase):
         lead = self._create_lead(self.partner_ca)
         lead.partner_id = False
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_not_called()
         self.assertEqual(lead.stage_id, self.origin_stage)
 
@@ -93,14 +94,14 @@ class TestSendWelcomeEmail(TransactionCase):
         lead = self._create_lead(self.partner_no_email)
         lead.email_from = False
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_not_called()
         self.assertEqual(lead.stage_id, self.origin_stage)
 
     def test_skips_lead_in_wrong_stage(self):
         lead = self._create_lead(self.partner_ca, stage=self.target_stage)
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_not_called()
         self.assertEqual(lead.stage_id, self.target_stage)
 
@@ -108,7 +109,7 @@ class TestSendWelcomeEmail(TransactionCase):
         self.env.company.som_crm_lead_welcome_template_id = False
         lead = self._create_lead(self.partner_ca)
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_not_called()
         # restore
         self.env.company.som_crm_lead_welcome_template_id = self.template_ca
@@ -117,7 +118,7 @@ class TestSendWelcomeEmail(TransactionCase):
         self.env.company.som_crm_lead_welcome_stage_id = False
         lead = self._create_lead(self.partner_ca)
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
-            lead._send_welcome_email()
+            lead._process_welcome()
             mock_send.assert_not_called()
         # restore
         self.env.company.som_crm_lead_welcome_stage_id = self.target_stage
@@ -132,17 +133,63 @@ class TestSendWelcomeEmail(TransactionCase):
 
         with patch.object(type(self.template_ca), 'send_mail', side_effect=mock_send), \
              patch.object(type(self.template_es), 'send_mail', side_effect=mock_send):
-            (lead_ca | lead_es)._send_welcome_email()
+            (lead_ca | lead_es)._process_welcome()
 
         self.assertEqual(lead_ca.stage_id, self.origin_stage)
         self.assertEqual(lead_es.stage_id, self.target_stage)
         self.assertEqual(lead_ca.stage_id, self.origin_stage)
         self.assertEqual(lead_es.stage_id, self.target_stage)
 
-    # --- _send_welcome_email_cron ---
+    # --- _process_welcome_cron ---
 
     def test_cron_finds_eligible_leads(self):
         lead = self._create_lead(self.partner_ca)
         with patch.object(type(self.template_ca), 'send_mail'):
-            self.env['crm.lead']._send_welcome_email_cron()
+            self.env['crm.lead']._process_welcome_cron()
         self.assertEqual(lead.stage_id, self.target_stage)
+
+    # --- activitats obertes ---
+
+    def _create_activity(self, lead):
+        activity_type = self.env.ref(
+            'mail.mail_activity_data_todo', raise_if_not_found=False
+        ) or self.env['mail.activity.type'].search([], limit=1)
+        return self.env['mail.activity'].create({
+            'res_model_id': self.env['ir.model']._get('crm.lead').id,
+            'res_id': lead.id,
+            'activity_type_id': activity_type.id,
+            'summary': 'Activitat de prova',
+            'user_id': self.env.user.id,
+            'date_deadline': date.today(),
+        })
+
+    def test_activities_marked_done_on_success(self):
+        lead = self._create_lead(self.partner_ca)
+        activity = self._create_activity(lead)
+        self.assertTrue(activity.exists())
+
+        with patch.object(type(self.template_ca), 'send_mail'):
+            lead._process_welcome()
+
+        self.assertFalse(activity.exists())
+        self.assertEqual(lead.stage_id, self.target_stage)
+
+    def test_no_activities_does_not_fail(self):
+        lead = self._create_lead(self.partner_ca)
+        lead.activity_ids.unlink()
+
+        with patch.object(type(self.template_ca), 'send_mail'):
+            lead._process_welcome()
+
+        self.assertEqual(lead.stage_id, self.target_stage)
+
+    def test_activities_not_marked_done_if_email_fails(self):
+        lead = self._create_lead(self.partner_ca)
+        activity = self._create_activity(lead)
+        self.assertTrue(activity.exists())
+
+        with patch.object(type(self.template_ca), 'send_mail', side_effect=Exception("SMTP error")):
+            lead._process_welcome()
+
+        self.assertTrue(activity.exists())
+        self.assertEqual(lead.stage_id, self.origin_stage)


### PR DESCRIPTION
## Description
Related with PR https://github.com/Som-Energia/somenergia-odoo/pull/78

https://somenergia.openproject.com/wp/1452




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes open activities when processing the lead welcome flow and renames the flow from “send welcome email” to “process welcome” for clarity. Activities are cleared only after a successful email send and stage change.

- **New Features**
  - Added activity cleanup in `crm.lead._process_welcome()` (`lead.activity_ids.unlink()`) after successful send and stage update; activities remain if sending fails.
  - Renamed methods to `_process_welcome` and `_process_welcome_cron`; updated cron to `som_crm_lead_process_welcome` (old `som_crm_lead_welcome_email` set inactive) and server action to `som_crm_action_process_welcome`.
  - Tests updated to cover activity cleanup, no-activity cases, failure cases, and cron path.

<sup>Written for commit 32a503d846ca3b75a3aae98cb31551b9549f5c5b. Summary will update on new commits. <a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/86?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

