### PR TITLE
Add api doc with openapi

### DIFF
--- a/docs/crm_lead_api.json
+++ b/docs/crm_lead_api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Som Energia CRM API",
-    "description": "API REST per a la creació de leads al CRM de Som Energia.\n\n## Autenticació\n\nTotes les peticions requereixen un API Key al header `X-API-Key`.\n\n## Comportament automàtic en crear un lead\n\nEn crear un lead el sistema executa automàticament:\n- Assignació d'usuari responsable (`auto_assign_user`)\n- Creació d'activitat programada per avui\n- Extracció de paràmetres UTM de `url_origin`\n- Assignació de partner si escau\n- Enviament d'email de confirmació al contacte\n\nL'etapa i canal del lead s'assignen segons si s'adjunten fitxers:\n- **Sense fitxers:** etapa `Lead` + canal `Webform`\n- **Amb fitxers:** etapa `Simulació` + canal `Webform simulació`\n",
+    "description": "API REST per a la creació de leads al CRM de Som Energia.\n\n## Autenticació\n\nTotes les peticions requereixen un API Key al header `X-API-Key`.\n\n## Comportament automàtic en crear un lead\n\nEn crear un lead el sistema executa automàticament:\n- Assignació d'usuari responsable (`auto_assign_user`)\n- Creació d'activitat programada per avui\n- Extracció de paràmetres UTM de `url_origin`\n- Assignació de partner si escau\n- Enviament d'email de confirmació al contacte\n\nL'etapa i canal del lead s'assignen segons si s'adjunten fitxers:\n- **Sense fitxers:** etapa `Lead` + canal `Webform`\n- **Amb fitxers:** etapa `Simulació` + canal `Webform simulació`\n\n## Notes importants\n\n- El camp `lang` admet `ca_ES` i `es_ES`.  Si s'envia un altre valor, la petició no retorna error i l'idioma no s'assigna.\n",
     "version": "1.0.0",
     "contact": {
       "name": "Som Energia — Equip de desenvolupament"
@@ -257,7 +257,7 @@
               "ca_ES",
               "es_ES"
             ],
-            "description": "Idioma preferit del contacte.",
+            "description": "Idioma preferit del contacte. Valors suportats: ca_ES i es_ES. Si s'envia un valor diferent, la peticio no falla i l'idioma no s'assigna.",
             "example": "ca_ES"
           },
           "url_origin": {

--- a/docs/crm_lead_api.json
+++ b/docs/crm_lead_api.json
@@ -1,0 +1,419 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Som Energia CRM API",
+    "description": "API REST per a la creació de leads al CRM de Som Energia.\n\n## Autenticació\n\nTotes les peticions requereixen un API Key al header `X-API-Key`.\n\n## Comportament automàtic en crear un lead\n\nEn crear un lead el sistema executa automàticament:\n- Assignació d'usuari responsable (`auto_assign_user`)\n- Creació d'activitat programada per avui\n- Extracció de paràmetres UTM de `url_origin`\n- Assignació de partner si escau\n- Enviament d'email de confirmació al contacte\n\nL'etapa i canal del lead s'assignen segons si s'adjunten fitxers:\n- **Sense fitxers:** etapa `Lead` + canal `Webform`\n- **Amb fitxers:** etapa `Simulació` + canal `Webform simulació`\n",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Som Energia — Equip de desenvolupament"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://example.invalid",
+      "description": "Només documentació (endpoint no executable des d'aquest document)"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "paths": {
+    "/api/crm/lead": {
+      "post": {
+        "summary": "Crear un lead al CRM",
+        "description": "Crea un nou lead al CRM d'Odoo. Tots els camps del cos de la petició\nsón opcionals. Si s'adjunten fitxers, el lead s'associa al canal de\nsimulació i s'envia la confirmació indicant que s'han rebut documents.\n",
+        "operationId": "createLead",
+        "tags": [
+          "Leads"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLeadRequest"
+              },
+              "examples": {
+                "sense_fitxers": {
+                  "summary": "Lead bàsic sense fitxers",
+                  "value": {
+                    "contact_name": "Maria Garcia",
+                    "email": "maria.garcia@example.com",
+                    "phone": "+34 612 345 678",
+                    "lang": "ca_ES",
+                    "url_origin": "https://www.somenergia.coop/ca/tarifes/?utm_source=google&utm_medium=cpc&utm_campaign=tarifes_2024",
+                    "comments": "Interessada en tarifa per a comunitat de veïns"
+                  }
+                },
+                "amb_fitxers": {
+                  "summary": "Lead amb documents adjunts",
+                  "value": {
+                    "contact_name": "Joan Puig",
+                    "email": "joan.puig@example.com",
+                    "phone": "+34 699 111 222",
+                    "lang": "es_ES",
+                    "url_origin": "https://www.somenergia.coop/es/simulacion/",
+                    "comments": "Adjunto factura per a simulació",
+                    "files": [
+                      {
+                        "filename": "factura_llum.pdf",
+                        "content": "JVBERi0xLjQKJ...",
+                        "mimetype": "application/pdf"
+                      },
+                      {
+                        "filename": "foto_comptador.jpg",
+                        "content": "/9j/4AAQSkZJRg...",
+                        "mimetype": "image/jpeg"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lead creat correctament",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateLeadResponse"
+                },
+                "examples": {
+                  "sense_fitxers": {
+                    "summary": "Resposta sense fitxers adjunts",
+                    "value": {
+                      "success": true,
+                      "message": "Lead successfully created",
+                      "lead_id": 123,
+                      "lead_name": "Maria Garcia",
+                      "lead_data": {
+                        "id": 123,
+                        "name": "Maria Garcia",
+                        "contact_name": "Maria Garcia",
+                        "email_from": "maria.garcia@example.com",
+                        "phone": "+34612345678",
+                        "create_date": "2026-05-27T10:00:00"
+                      }
+                    }
+                  },
+                  "amb_fitxers": {
+                    "summary": "Resposta amb fitxers adjunts",
+                    "value": {
+                      "success": true,
+                      "message": "Lead successfully created",
+                      "lead_id": 124,
+                      "lead_name": "Joan Puig",
+                      "lead_data": {
+                        "id": 124,
+                        "name": "Joan Puig",
+                        "contact_name": "Joan Puig",
+                        "email_from": "joan.puig@example.com",
+                        "phone": "+34699111222",
+                        "create_date": "2026-05-27T11:30:00"
+                      },
+                      "attachments": [
+                        {
+                          "id": 45,
+                          "name": "factura_llum.pdf",
+                          "mimetype": "application/pdf",
+                          "file_size": 102400
+                        },
+                        {
+                          "id": 46,
+                          "name": "foto_comptador.jpg",
+                          "mimetype": "image/jpeg",
+                          "file_size": 204800
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Petició invàlida — JSON mal format o error de validació",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "json_invalid": {
+                    "summary": "JSON mal format",
+                    "value": {
+                      "success": false,
+                      "error": "Invalid JSON",
+                      "message": "The request body is not valid JSON"
+                    }
+                  },
+                  "validacio": {
+                    "summary": "Error de validació de camp",
+                    "value": {
+                      "success": false,
+                      "error": "Validation error",
+                      "message": "lang must be one of: ca_ES, es_ES"
+                    }
+                  },
+                  "fitxer_massa_gran": {
+                    "summary": "Fitxer supera el límit de mida",
+                    "value": {
+                      "success": false,
+                      "error": "Validation error",
+                      "message": "File 'document.pdf' exceeds maximum size of 10MB"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No autenticat — falta la X-API-Key o és invàlida",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Authentication required",
+                "message": "Provide a valid X-API-Key in the request headers"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Accés denegat",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Access error",
+                  "message": "You do not have permission to perform this action"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error intern del servidor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Internal server error",
+                  "message": "An unexpected error occurred. Please contact support."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "API Key proporcionada per Som Energia. Es configura al paràmetre de sistema `som_crm.api_key` de l'instància Odoo.\n"
+      }
+    },
+    "schemas": {
+      "CreateLeadRequest": {
+        "type": "object",
+        "description": "Tots els camps són opcionals. Es pot enviar un cos buit `{}` o fins i tot una petició sense cos.\n",
+        "properties": {
+          "contact_name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Nom complet del contacte. Es guarda en format Title Case (primera lletra de cada paraula en majúscula).\n",
+            "example": "Maria Garcia"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Adreça de correu electrònic del contacte. Es normalitza a minúscules i s'eliminen espais als extrems.\n",
+            "example": "maria.garcia@example.com"
+          },
+          "phone": {
+            "type": "string",
+            "description": "Número de telèfon del contacte. S'eliminen tots els espais abans de desar-lo.\n",
+            "example": "+34 612 345 678"
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ca_ES",
+              "es_ES"
+            ],
+            "description": "Idioma preferit del contacte.",
+            "example": "ca_ES"
+          },
+          "url_origin": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL de la pàgina d'origen de la petició. Els paràmetres UTM (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`) s'extreuen automàticament i s'associen al lead.\n",
+            "example": "https://www.somenergia.coop/ca/tarifes/?utm_source=google&utm_medium=cpc&utm_campaign=tarifes_2024"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comentaris lliures del contacte. S'afegeixen com a nota interna al xatter del lead.\n",
+            "example": "Interessada en tarifa per a comunitat de veïns"
+          },
+          "files": {
+            "type": "array",
+            "description": "Llista de fitxers adjunts. Restriccions:\n- Mida màxima per fitxer: **10 MB**\n- Mida total màxima de tots els fitxers: **50 MB**\n- Tipus MIME permesos: `image/jpeg`, `image/png`, `image/gif`,\n  `image/bmp`, `image/webp`, `application/pdf`,\n  `application/msword`,\n  `application/vnd.openxmlformats-officedocument.wordprocessingml.document`,\n  `application/vnd.ms-excel`,\n  `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`,\n  `application/vnd.ms-powerpoint`,\n  `application/vnd.openxmlformats-officedocument.presentationml.presentation`,\n  `text/plain`, `text/csv`, `application/zip`,\n  `application/x-rar-compressed`\n",
+            "items": {
+              "$ref": "#/components/schemas/FileObject"
+            }
+          }
+        }
+      },
+      "FileObject": {
+        "type": "object",
+        "required": [
+          "filename",
+          "content"
+        ],
+        "properties": {
+          "filename": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Nom del fitxer incloent l'extensió.",
+            "example": "factura_llum.pdf"
+          },
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Contingut del fitxer codificat en **Base64**. Mida màxima descodificada: 10 MB per fitxer.\n",
+            "example": "JVBERi0xLjQKJ..."
+          },
+          "mimetype": {
+            "type": "string",
+            "description": "Tipus MIME del fitxer. Si s'omet, el sistema intentarà detectar-lo automàticament a partir de l'extensió del `filename`.\n",
+            "example": "application/pdf"
+          }
+        }
+      },
+      "CreateLeadResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "Lead successfully created"
+          },
+          "lead_id": {
+            "type": "integer",
+            "description": "Identificador intern del lead creat a Odoo.",
+            "example": 123
+          },
+          "lead_name": {
+            "type": "string",
+            "description": "Nom del lead tal com s'ha creat.",
+            "example": "Maria Garcia"
+          },
+          "lead_data": {
+            "$ref": "#/components/schemas/LeadData"
+          },
+          "attachments": {
+            "type": "array",
+            "description": "Només present si s'han adjuntat fitxers a la petició.\n",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentInfo"
+            }
+          }
+        }
+      },
+      "LeadData": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 123
+          },
+          "name": {
+            "type": "string",
+            "example": "Maria Garcia"
+          },
+          "contact_name": {
+            "type": "string",
+            "example": "Maria Garcia"
+          },
+          "email_from": {
+            "type": "string",
+            "format": "email",
+            "example": "maria.garcia@example.com"
+          },
+          "phone": {
+            "type": "string",
+            "example": "+34612345678"
+          },
+          "create_date": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Data i hora de creació del lead en format ISO 8601 (UTC).",
+            "example": "2026-05-27T10:00:00"
+          }
+        }
+      },
+      "AttachmentInfo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Identificador intern de l'adjunt a Odoo.",
+            "example": 45
+          },
+          "name": {
+            "type": "string",
+            "description": "Nom del fitxer adjunt.",
+            "example": "factura_llum.pdf"
+          },
+          "mimetype": {
+            "type": "string",
+            "example": "application/pdf"
+          },
+          "file_size": {
+            "type": "integer",
+            "description": "Mida del fitxer en bytes.",
+            "example": 102400
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Codi d'error llegible per màquina.",
+            "example": "Validation error"
+          },
+          "message": {
+            "type": "string",
+            "description": "Descripció detallada de l'error per a humans.",
+            "example": "lang must be one of: ca_ES, es_ES"
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="ca">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>somenergia-odoo — CRM Lead API docs</title>
+    <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
+    <style>
+      body {
+        margin: 0;
+        font-family: "Source Sans 3", "Segoe UI", sans-serif;
+        background: #f6f8fb;
+      }
+
+      header {
+        padding: 16px 20px;
+        background: #0e3a53;
+        color: #fff;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: 1.1rem;
+      }
+
+      p {
+        margin: 6px 0 0;
+        opacity: 0.9;
+        font-size: 0.9rem;
+      }
+
+      #swagger-ui {
+        margin: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Som Energia CRM API - create_lead</h1>
+      <p>Documentacio OpenAPI de consulta (sense execucio de crides)</p>
+    </header>
+    <div id="swagger-ui"></div>
+
+    <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
+    <script>
+      SwaggerUIBundle({
+        url: "./crm_lead_api.json",
+        dom_id: "#swagger-ui",
+        deepLinking: true,
+        supportedSubmitMethods: []
+      });
+    </script>
+  </body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>somenergia-odoo — CRM Lead API docs</title>
+    <title>somenergia-odoo - API docs</title>
     <link rel="stylesheet" href="https://unpkg.com/swagger-ui-dist/swagger-ui.css" />
     <style>
       body {
@@ -29,6 +29,26 @@
         font-size: 0.9rem;
       }
 
+      .controls {
+        margin-top: 10px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        flex-wrap: wrap;
+      }
+
+      label {
+        font-size: 0.9rem;
+      }
+
+      select {
+        min-width: 260px;
+        border: 1px solid #b4c5d1;
+        border-radius: 6px;
+        padding: 6px 8px;
+        font-size: 0.92rem;
+      }
+
       #swagger-ui {
         margin: 0;
       }
@@ -36,19 +56,64 @@
   </head>
   <body>
     <header>
-      <h1>Som Energia CRM API - create_lead</h1>
+      <h1>Som Energia API documentation</h1>
       <p>Documentacio OpenAPI de consulta (sense execucio de crides)</p>
+      <div class="controls">
+        <label for="spec-select">Endpoint:</label>
+        <select id="spec-select"></select>
+      </div>
     </header>
     <div id="swagger-ui"></div>
 
     <script src="https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js"></script>
     <script>
-      SwaggerUIBundle({
-        url: "./crm_lead_api.json",
-        dom_id: "#swagger-ui",
-        deepLinking: true,
-        supportedSubmitMethods: []
+      const SPECS = [
+        { label: "CRM - Create lead", file: "crm_lead_api.json" }
+      ];
+
+      const select = document.getElementById("spec-select");
+
+      function loadSpec(file) {
+        SwaggerUIBundle({
+          url: `./${file}`,
+          dom_id: "#swagger-ui",
+          deepLinking: true,
+          supportedSubmitMethods: []
+        });
+      }
+
+      function isValidSpec(file) {
+        return SPECS.some((spec) => spec.file === file);
+      }
+
+      function setQuerySpec(file) {
+        const params = new URLSearchParams(window.location.search);
+        params.set("spec", file);
+        const qs = params.toString();
+        const nextUrl = `${window.location.pathname}${qs ? `?${qs}` : ""}`;
+        window.history.replaceState({}, "", nextUrl);
+      }
+
+      SPECS.forEach((spec) => {
+        const option = document.createElement("option");
+        option.value = spec.file;
+        option.textContent = spec.label;
+        select.appendChild(option);
       });
+
+      select.addEventListener("change", (event) => {
+        const file = event.target.value;
+        setQuerySpec(file);
+        loadSpec(file);
+      });
+
+      const requestedSpec = new URLSearchParams(window.location.search).get("spec");
+      const defaultSpec = SPECS[0].file;
+      const currentSpec = isValidSpec(requestedSpec) ? requestedSpec : defaultSpec;
+
+      select.value = currentSpec;
+      setQuerySpec(currentSpec);
+      loadSpec(currentSpec);
     </script>
   </body>
 </html>

--- a/som_crm/docs/crm_lead_api.json
+++ b/som_crm/docs/crm_lead_api.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.3",
   "info": {
     "title": "Som Energia CRM API",
-    "description": "API REST per a la creació de leads al CRM de Som Energia.\n\n## Autenticació\n\nTotes les peticions requereixen un API Key al header `X-API-Key`.\n\n## Comportament automàtic en crear un lead\n\nEn crear un lead el sistema executa automàticament:\n- Assignació d'usuari responsable (`auto_assign_user`)\n- Creació d'activitat programada per avui\n- Extracció de paràmetres UTM de `url_origin`\n- Assignació de partner si escau\n- Enviament d'email de confirmació al contacte\n\nL'etapa i canal del lead s'assignen segons si s'adjunten fitxers:\n- **Sense fitxers:** etapa `Lead` + canal `Webform`\n- **Amb fitxers:** etapa `Simulació` + canal `Webform simulació`\n",
+    "description": "API REST per a la creació de leads al CRM de Som Energia.\n\n## Autenticació\n\nTotes les peticions requereixen un API Key al header `X-API-Key`.\n\n## Comportament automàtic en crear un lead\n\nEn crear un lead el sistema executa automàticament:\n- Assignació d'usuari responsable (`auto_assign_user`)\n- Creació d'activitat programada per avui\n- Extracció de paràmetres UTM de `url_origin`\n- Assignació de partner si escau\n- Enviament d'email de confirmació al contacte\n\nL'etapa i canal del lead s'assignen segons si s'adjunten fitxers:\n- **Sense fitxers:** etapa `Lead` + canal `Webform`\n- **Amb fitxers:** etapa `Simulació` + canal `Webform simulació`\n\n## Notes importants\n\n- El camp `lang` admet `ca_ES` i `es_ES`.  Si s'envia un altre valor, la petició no retorna error i l'idioma no s'assigna.\n",
     "version": "1.0.0",
     "contact": {
       "name": "Som Energia — Equip de desenvolupament"
@@ -257,7 +257,7 @@
               "ca_ES",
               "es_ES"
             ],
-            "description": "Idioma preferit del contacte.",
+            "description": "Idioma preferit del contacte. Valors suportats: ca_ES i es_ES. Si s'envia un valor diferent, la peticio no falla i l'idioma no s'assigna.",
             "example": "ca_ES"
           },
           "url_origin": {

--- a/som_crm/docs/crm_lead_api.json
+++ b/som_crm/docs/crm_lead_api.json
@@ -1,0 +1,419 @@
+{
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Som Energia CRM API",
+    "description": "API REST per a la creació de leads al CRM de Som Energia.\n\n## Autenticació\n\nTotes les peticions requereixen un API Key al header `X-API-Key`.\n\n## Comportament automàtic en crear un lead\n\nEn crear un lead el sistema executa automàticament:\n- Assignació d'usuari responsable (`auto_assign_user`)\n- Creació d'activitat programada per avui\n- Extracció de paràmetres UTM de `url_origin`\n- Assignació de partner si escau\n- Enviament d'email de confirmació al contacte\n\nL'etapa i canal del lead s'assignen segons si s'adjunten fitxers:\n- **Sense fitxers:** etapa `Lead` + canal `Webform`\n- **Amb fitxers:** etapa `Simulació` + canal `Webform simulació`\n",
+    "version": "1.0.0",
+    "contact": {
+      "name": "Som Energia — Equip de desenvolupament"
+    }
+  },
+  "servers": [
+    {
+      "url": "https://example.invalid",
+      "description": "Només documentació (endpoint no executable des d'aquest document)"
+    }
+  ],
+  "security": [
+    {
+      "ApiKeyAuth": []
+    }
+  ],
+  "paths": {
+    "/api/crm/lead": {
+      "post": {
+        "summary": "Crear un lead al CRM",
+        "description": "Crea un nou lead al CRM d'Odoo. Tots els camps del cos de la petició\nsón opcionals. Si s'adjunten fitxers, el lead s'associa al canal de\nsimulació i s'envia la confirmació indicant que s'han rebut documents.\n",
+        "operationId": "createLead",
+        "tags": [
+          "Leads"
+        ],
+        "requestBody": {
+          "required": false,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateLeadRequest"
+              },
+              "examples": {
+                "sense_fitxers": {
+                  "summary": "Lead bàsic sense fitxers",
+                  "value": {
+                    "contact_name": "Maria Garcia",
+                    "email": "maria.garcia@example.com",
+                    "phone": "+34 612 345 678",
+                    "lang": "ca_ES",
+                    "url_origin": "https://www.somenergia.coop/ca/tarifes/?utm_source=google&utm_medium=cpc&utm_campaign=tarifes_2024",
+                    "comments": "Interessada en tarifa per a comunitat de veïns"
+                  }
+                },
+                "amb_fitxers": {
+                  "summary": "Lead amb documents adjunts",
+                  "value": {
+                    "contact_name": "Joan Puig",
+                    "email": "joan.puig@example.com",
+                    "phone": "+34 699 111 222",
+                    "lang": "es_ES",
+                    "url_origin": "https://www.somenergia.coop/es/simulacion/",
+                    "comments": "Adjunto factura per a simulació",
+                    "files": [
+                      {
+                        "filename": "factura_llum.pdf",
+                        "content": "JVBERi0xLjQKJ...",
+                        "mimetype": "application/pdf"
+                      },
+                      {
+                        "filename": "foto_comptador.jpg",
+                        "content": "/9j/4AAQSkZJRg...",
+                        "mimetype": "image/jpeg"
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Lead creat correctament",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateLeadResponse"
+                },
+                "examples": {
+                  "sense_fitxers": {
+                    "summary": "Resposta sense fitxers adjunts",
+                    "value": {
+                      "success": true,
+                      "message": "Lead successfully created",
+                      "lead_id": 123,
+                      "lead_name": "Maria Garcia",
+                      "lead_data": {
+                        "id": 123,
+                        "name": "Maria Garcia",
+                        "contact_name": "Maria Garcia",
+                        "email_from": "maria.garcia@example.com",
+                        "phone": "+34612345678",
+                        "create_date": "2026-05-27T10:00:00"
+                      }
+                    }
+                  },
+                  "amb_fitxers": {
+                    "summary": "Resposta amb fitxers adjunts",
+                    "value": {
+                      "success": true,
+                      "message": "Lead successfully created",
+                      "lead_id": 124,
+                      "lead_name": "Joan Puig",
+                      "lead_data": {
+                        "id": 124,
+                        "name": "Joan Puig",
+                        "contact_name": "Joan Puig",
+                        "email_from": "joan.puig@example.com",
+                        "phone": "+34699111222",
+                        "create_date": "2026-05-27T11:30:00"
+                      },
+                      "attachments": [
+                        {
+                          "id": 45,
+                          "name": "factura_llum.pdf",
+                          "mimetype": "application/pdf",
+                          "file_size": 102400
+                        },
+                        {
+                          "id": 46,
+                          "name": "foto_comptador.jpg",
+                          "mimetype": "image/jpeg",
+                          "file_size": 204800
+                        }
+                      ]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Petició invàlida — JSON mal format o error de validació",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "examples": {
+                  "json_invalid": {
+                    "summary": "JSON mal format",
+                    "value": {
+                      "success": false,
+                      "error": "Invalid JSON",
+                      "message": "The request body is not valid JSON"
+                    }
+                  },
+                  "validacio": {
+                    "summary": "Error de validació de camp",
+                    "value": {
+                      "success": false,
+                      "error": "Validation error",
+                      "message": "lang must be one of: ca_ES, es_ES"
+                    }
+                  },
+                  "fitxer_massa_gran": {
+                    "summary": "Fitxer supera el límit de mida",
+                    "value": {
+                      "success": false,
+                      "error": "Validation error",
+                      "message": "File 'document.pdf' exceeds maximum size of 10MB"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "No autenticat — falta la X-API-Key o és invàlida",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Authentication required",
+                "message": "Provide a valid X-API-Key in the request headers"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Accés denegat",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Access error",
+                  "message": "You do not have permission to perform this action"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Error intern del servidor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                },
+                "example": {
+                  "success": false,
+                  "error": "Internal server error",
+                  "message": "An unexpected error occurred. Please contact support."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key",
+        "description": "API Key proporcionada per Som Energia. Es configura al paràmetre de sistema `som_crm.api_key` de l'instància Odoo.\n"
+      }
+    },
+    "schemas": {
+      "CreateLeadRequest": {
+        "type": "object",
+        "description": "Tots els camps són opcionals. Es pot enviar un cos buit `{}` o fins i tot una petició sense cos.\n",
+        "properties": {
+          "contact_name": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Nom complet del contacte. Es guarda en format Title Case (primera lletra de cada paraula en majúscula).\n",
+            "example": "Maria Garcia"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "description": "Adreça de correu electrònic del contacte. Es normalitza a minúscules i s'eliminen espais als extrems.\n",
+            "example": "maria.garcia@example.com"
+          },
+          "phone": {
+            "type": "string",
+            "description": "Número de telèfon del contacte. S'eliminen tots els espais abans de desar-lo.\n",
+            "example": "+34 612 345 678"
+          },
+          "lang": {
+            "type": "string",
+            "enum": [
+              "ca_ES",
+              "es_ES"
+            ],
+            "description": "Idioma preferit del contacte.",
+            "example": "ca_ES"
+          },
+          "url_origin": {
+            "type": "string",
+            "format": "uri",
+            "description": "URL de la pàgina d'origen de la petició. Els paràmetres UTM (`utm_source`, `utm_medium`, `utm_campaign`, `utm_term`, `utm_content`) s'extreuen automàticament i s'associen al lead.\n",
+            "example": "https://www.somenergia.coop/ca/tarifes/?utm_source=google&utm_medium=cpc&utm_campaign=tarifes_2024"
+          },
+          "comments": {
+            "type": "string",
+            "description": "Comentaris lliures del contacte. S'afegeixen com a nota interna al xatter del lead.\n",
+            "example": "Interessada en tarifa per a comunitat de veïns"
+          },
+          "files": {
+            "type": "array",
+            "description": "Llista de fitxers adjunts. Restriccions:\n- Mida màxima per fitxer: **10 MB**\n- Mida total màxima de tots els fitxers: **50 MB**\n- Tipus MIME permesos: `image/jpeg`, `image/png`, `image/gif`,\n  `image/bmp`, `image/webp`, `application/pdf`,\n  `application/msword`,\n  `application/vnd.openxmlformats-officedocument.wordprocessingml.document`,\n  `application/vnd.ms-excel`,\n  `application/vnd.openxmlformats-officedocument.spreadsheetml.sheet`,\n  `application/vnd.ms-powerpoint`,\n  `application/vnd.openxmlformats-officedocument.presentationml.presentation`,\n  `text/plain`, `text/csv`, `application/zip`,\n  `application/x-rar-compressed`\n",
+            "items": {
+              "$ref": "#/components/schemas/FileObject"
+            }
+          }
+        }
+      },
+      "FileObject": {
+        "type": "object",
+        "required": [
+          "filename",
+          "content"
+        ],
+        "properties": {
+          "filename": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Nom del fitxer incloent l'extensió.",
+            "example": "factura_llum.pdf"
+          },
+          "content": {
+            "type": "string",
+            "format": "byte",
+            "description": "Contingut del fitxer codificat en **Base64**. Mida màxima descodificada: 10 MB per fitxer.\n",
+            "example": "JVBERi0xLjQKJ..."
+          },
+          "mimetype": {
+            "type": "string",
+            "description": "Tipus MIME del fitxer. Si s'omet, el sistema intentarà detectar-lo automàticament a partir de l'extensió del `filename`.\n",
+            "example": "application/pdf"
+          }
+        }
+      },
+      "CreateLeadResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": true
+          },
+          "message": {
+            "type": "string",
+            "example": "Lead successfully created"
+          },
+          "lead_id": {
+            "type": "integer",
+            "description": "Identificador intern del lead creat a Odoo.",
+            "example": 123
+          },
+          "lead_name": {
+            "type": "string",
+            "description": "Nom del lead tal com s'ha creat.",
+            "example": "Maria Garcia"
+          },
+          "lead_data": {
+            "$ref": "#/components/schemas/LeadData"
+          },
+          "attachments": {
+            "type": "array",
+            "description": "Només present si s'han adjuntat fitxers a la petició.\n",
+            "items": {
+              "$ref": "#/components/schemas/AttachmentInfo"
+            }
+          }
+        }
+      },
+      "LeadData": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "example": 123
+          },
+          "name": {
+            "type": "string",
+            "example": "Maria Garcia"
+          },
+          "contact_name": {
+            "type": "string",
+            "example": "Maria Garcia"
+          },
+          "email_from": {
+            "type": "string",
+            "format": "email",
+            "example": "maria.garcia@example.com"
+          },
+          "phone": {
+            "type": "string",
+            "example": "+34612345678"
+          },
+          "create_date": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Data i hora de creació del lead en format ISO 8601 (UTC).",
+            "example": "2026-05-27T10:00:00"
+          }
+        }
+      },
+      "AttachmentInfo": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Identificador intern de l'adjunt a Odoo.",
+            "example": 45
+          },
+          "name": {
+            "type": "string",
+            "description": "Nom del fitxer adjunt.",
+            "example": "factura_llum.pdf"
+          },
+          "mimetype": {
+            "type": "string",
+            "example": "application/pdf"
+          },
+          "file_size": {
+            "type": "integer",
+            "description": "Mida del fitxer en bytes.",
+            "example": 102400
+          }
+        }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "example": false
+          },
+          "error": {
+            "type": "string",
+            "description": "Codi d'error llegible per màquina.",
+            "example": "Validation error"
+          },
+          "message": {
+            "type": "string",
+            "description": "Descripció detallada de l'error per a humans.",
+            "example": "lang must be one of: ca_ES, es_ES"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
https://somenergia.openproject.com/wp/1665



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenAPI 3.0 docs for the CRM lead creation endpoint and a read-only Swagger UI to browse them. Includes a spec selector to host multiple specs on one page.

- **New Features**
  - Added OpenAPI spec for POST `/api/crm/lead` in `docs/crm_lead_api.json` and `som_crm/docs/crm_lead_api.json` (header `X-API-Key`, examples, attachment limits, error responses, `lang` accepts `ca_ES`/`es_ES`; other values are ignored).
  - Added `docs/index.html` with a read-only Swagger UI (no “Try it out”) and a `?spec=` selector.

<sup>Written for commit f0ecce7e49d8f560fff9d69c5d3b5ed298284b41. Summary will update on new commits. <a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/88?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



