### PR TITLE
🐛 Fix template seleccion in welcome process by lead lang

### DIFF
--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -1240,7 +1240,7 @@ class Lead(models.Model):
             lambda x: x.stage_id == origin_stage and x.partner_id and x.email_from
         ):
             try:
-                lang = lead.partner_id.lang or ''
+                lang = lead.lang_id.code or ''
                 is_spanish = lang_es and lang == lang_es.code
                 template = template_es if (is_spanish and template_es) else template_ca
                 template.send_mail(lead.id, force_send=True)

--- a/som_crm/tests/test_crm_lead_welcome_email.py
+++ b/som_crm/tests/test_crm_lead_welcome_email.py
@@ -48,13 +48,16 @@ class TestSendWelcomeEmail(TransactionCase):
         cls.env.company.som_crm_lead_welcome_template_es_id = cls.template_es
         cls.env.company.som_crm_lead_welcome_stage_id = cls.target_stage
 
-    def _create_lead(self, partner, stage=None):
-        return self.env['crm.lead'].create({
+    def _create_lead(self, partner, stage=None, lang=None):
+        vals = {
             'name': f'Lead {partner.name}',
             'partner_id': partner.id,
             'email_from': partner.email,
             'stage_id': (stage or self.origin_stage).id,
-        })
+        }
+        if lang:
+            vals['lang_id'] = lang.id
+        return self.env['crm.lead'].create(vals)
 
     # --- _process_welcome ---
 
@@ -66,7 +69,7 @@ class TestSendWelcomeEmail(TransactionCase):
         self.assertEqual(lead.stage_id, self.target_stage)
 
     def test_es_partner_uses_es_template(self):
-        lead = self._create_lead(self.partner_es)
+        lead = self._create_lead(self.partner_es, lang=self.lang_es)
         with patch.object(type(self.template_es), 'send_mail') as mock_send:
             lead._process_welcome()
             mock_send.assert_called_once_with(lead.id, force_send=True)
@@ -74,13 +77,20 @@ class TestSendWelcomeEmail(TransactionCase):
 
     def test_es_partner_falls_back_to_ca_if_no_es_template(self):
         self.env.company.som_crm_lead_welcome_template_es_id = False
-        lead = self._create_lead(self.partner_es)
+        lead = self._create_lead(self.partner_es, lang=self.lang_es)
         with patch.object(type(self.template_ca), 'send_mail') as mock_send:
             lead._process_welcome()
             mock_send.assert_called_once_with(lead.id, force_send=True)
         self.assertEqual(lead.stage_id, self.target_stage)
         # restore
         self.env.company.som_crm_lead_welcome_template_es_id = self.template_es
+
+    def test_falls_back_to_ca_when_lead_lang_is_empty(self):
+        lead = self._create_lead(self.partner_es)
+        with patch.object(type(self.template_ca), 'send_mail') as mock_send:
+            lead._process_welcome()
+            mock_send.assert_called_once_with(lead.id, force_send=True)
+        self.assertEqual(lead.stage_id, self.target_stage)
 
     def test_skips_lead_without_partner(self):
         lead = self._create_lead(self.partner_ca)


### PR DESCRIPTION
## Description




<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix welcome email template selection to use the lead’s language (`lang_id`) instead of the partner’s language. Ensures the correct ES/CA template is sent and avoids mismatches.

- **Bug Fixes**
  - Detect Spanish using `lead.lang_id.code`; default to CA template otherwise.
  - Updated tests: ES uses ES template; fall back to CA when ES template is missing or the lead has no language.

<sup>Written for commit a7947463affe94a99730e72a74c1b4859ee4a264. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/90?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

