### PR TITLE
✨(feat) timesheet period lock management

### DIFF
--- a/somenergia_custom/__manifest__.py
+++ b/somenergia_custom/__manifest__.py
@@ -16,7 +16,7 @@
     # Check https://github.com/odoo/odoo/blob/12.0/odoo/addons/base/data/ir_module_category_data.xml
     # for the full list
     'category': 'Uncategorized',
-    'version': '16.0.1.0.0',
+    'version': '16.0.1.1.0',
     'license': 'AGPL-3',
 
     # any module necessary for this one to work correctly

--- a/somenergia_custom/data/data.xml
+++ b/somenergia_custom/data/data.xml
@@ -246,5 +246,24 @@
             </field>
         </record>
 
+        <!--Tancament automàtic de períodes d'imputació (dia 10 de cada mes)-->
+        <record model="ir.cron" id="som_update_timesheet_lock_date">
+            <field name="name">Som - Update timesheet lock date</field>
+            <field name="interval_number">1</field>
+            <field name="interval_type">months</field>
+            <field name="numbercall">-1</field>
+            <field
+                name="nextcall"
+                eval="(DateTime.now().replace(day=10) if DateTime.now().day &lt; 10 else (DateTime.now() + timedelta(days=25)).replace(day=10)).strftime('%Y-%m-%d 06:00:00')"
+            />
+            <field name="doall" eval="False" />
+            <field name="active" eval="False" />
+            <field name="model_id" ref="base.model_res_company" />
+            <field name="state">code</field>
+            <field name="code">
+                model._do_update_timesheet_lock_date()
+            </field>
+        </record>
+
     </data>
 </odoo>

--- a/somenergia_custom/migrations/16.0.1.1.0/post-migrate.py
+++ b/somenergia_custom/migrations/16.0.1.1.0/post-migrate.py
@@ -1,0 +1,153 @@
+import logging
+
+from odoo.api import Environment, SUPERUSER_ID
+
+
+_logger = logging.getLogger(__name__)
+
+
+OLD_PROJECT_END_DATE = '2026-06-10'
+NEW_PROJECT_START_DATE = '2026-06-13'
+NEW_PROJECT_MANAGER_ID = 281
+NEW_AREA_PROJECT_NAMES = [
+    'Trobades ET',
+    'Descans',
+    'Trobades estratègiques equips',
+    'Formació transversal',
+    'Formació específica',
+    'Sòcia de treball',
+    'Atenció',
+    "Gestió de l'atenció",
+    'Operativa comer',
+    'Operativa comer empresa',
+    'Fraus i anomalies',
+    'Reclamació deute pendent',
+    'Coordinació comer',
+    'Canvis normatius comer',
+    'Aprovisionament',
+    'Acció comercial B2B',
+    'Acció comercial B2C',
+    'Estratègia comercial',
+    'Producte tarifes',
+    'Anàlisi barrera 100€',
+    'Venda creuada Soms',
+    'Flux solar',
+    'Descompte social',
+    'Som Energia Activa',
+    'Actualització preus',
+    'Flexibilitat de la demanada',
+    'Hibridació de plantes',
+    'Gurb promoció',
+    'Gurb explotació',
+    'Representació',
+    'Generation kWh',
+    'Auvi',
+    'Som Comunitats',
+    "Xarxa d'instal.ladores",
+    'Coordinadora CE',
+    'Gestió de plantes de tercers',
+    'CAEs',
+    'Prospecció noves iniciatives',
+    'Treball amb CR',
+    'Pilotatge de la coope',
+    'Pla estratègic',
+    'Gestió de plantes pròpies',
+    'Creació noves plantes',
+    'Compliment jurídic',
+    'Jurídic comercialització',
+    'Jurídic generació',
+    'Jurídic cooperativisme',
+    'Marketing',
+    'Producte',
+    'Gestió oficina',
+    'Gestió laboral',
+    'Entorn laboral',
+    'Comptabilitat',
+    'Manteniment sistemes',
+    'Gestió de servidors propis',
+    'Helpdesk',
+    'Web',
+    'Oficina Virtual',
+    'Odoo laboral',
+    'Indicadors',
+    'ERP',
+    'Gestió IT',
+    'Esc[hola]',
+    'Assemblea General',
+    'Gran Conversa',
+    'Trobada Sòcies Activistes',
+    'Parcicipació sòcies',
+    'Formació a les sòcies',
+    'Lobby',
+    'Representació intercoop',
+    'Difusió',
+]
+
+
+def _close_legacy_projects(env, area_tag, transversal_tag, excluded_project):
+    Project = env['project.project']
+    domain = [
+        ('name', 'not in', NEW_AREA_PROJECT_NAMES),
+        '|',
+            ('date_start', '=', False),
+            ('date_start', '<=', OLD_PROJECT_END_DATE),
+        '|',
+            ('tag_ids', 'in', area_tag.ids),
+            ('tag_ids', 'in', transversal_tag.ids),
+    ]
+    if excluded_project:
+        domain.append(('id', '!=', excluded_project.id))
+    legacy_projects = Project.search(domain)
+    _logger.info("Closing %s legacy area/transversal projects", len(legacy_projects))
+    if legacy_projects:
+        legacy_projects.write({'date': OLD_PROJECT_END_DATE})
+
+
+def _create_or_align_new_area_projects(env, area_tag, transversal_tag):
+    Project = env['project.project']
+    existing_projects = Project.search([('name', 'in', NEW_AREA_PROJECT_NAMES)])
+    existing_by_name = {project.name: project for project in existing_projects}
+
+    to_create = []
+    for name in NEW_AREA_PROJECT_NAMES:
+        project = existing_by_name.get(name)
+        if project:
+            commands = []
+            if transversal_tag in project.tag_ids:
+                commands.append((3, transversal_tag.id))
+            if area_tag not in project.tag_ids:
+                commands.append((4, area_tag.id))
+            vals = {
+                'date_start': NEW_PROJECT_START_DATE,
+                'date': False,
+                'allow_timesheets': True,
+                'user_id': NEW_PROJECT_MANAGER_ID,
+            }
+            if commands:
+                vals['tag_ids'] = commands
+            project.write(vals)
+            continue
+
+        to_create.append({
+            'name': name,
+            'allow_timesheets': True,
+            'date_start': NEW_PROJECT_START_DATE,
+            'user_id': NEW_PROJECT_MANAGER_ID,
+            'tag_ids': [(6, 0, [area_tag.id])],
+        })
+
+    if to_create:
+        _logger.info("Creating %s new area projects", len(to_create))
+        Project.create(to_create)
+
+
+def migrate(cr, version):
+    env = Environment(cr, SUPERUSER_ID, {})
+    area_tag = env.ref('somenergia_custom.som_project_tag_area')
+    transversal_tag = env.ref('somenergia_custom.som_project_tag_transversal_project')
+    excluded_project = env.ref('somenergia_custom.som_cumulative_hours_project', raise_if_not_found=False)
+
+    _logger.info("Applying project validity rollout migration 16.0.1.1.0")
+    _close_legacy_projects(env, area_tag, transversal_tag, excluded_project)
+    _create_or_align_new_area_projects(env, area_tag, transversal_tag)
+    _logger.info("Project validity rollout migration finished")

--- a/somenergia_custom/migrations/16.0.1.1.0/post-migrate.py
+++ b/somenergia_custom/migrations/16.0.1.1.0/post-migrate.py
@@ -6,8 +6,8 @@ from odoo.api import Environment, SUPERUSER_ID
 _logger = logging.getLogger(__name__)
 
 
-OLD_PROJECT_END_DATE = '2026-06-10'
-NEW_PROJECT_START_DATE = '2026-06-13'
+OLD_PROJECT_END_DATE = '2026-07-10'
+NEW_PROJECT_START_DATE = '2026-07-13'
 NEW_PROJECT_MANAGER_ID = 281
 NEW_AREA_PROJECT_NAMES = [
     'Trobades ET',
@@ -103,7 +103,18 @@ def _close_legacy_projects(env, area_tag, transversal_tag, excluded_project):
         legacy_projects.write({'date': OLD_PROJECT_END_DATE})
 
 
-def _create_or_align_new_area_projects(env, area_tag, transversal_tag):
+def _get_new_project_manager_id(env):
+    manager = env['res.users'].browse(NEW_PROJECT_MANAGER_ID).exists()
+    if not manager:
+        _logger.warning(
+            "User %s not found. New rollout projects will be created without user_id.",
+            NEW_PROJECT_MANAGER_ID,
+        )
+        return False
+    return manager.id
+
+
+def _create_or_align_new_area_projects(env, area_tag, transversal_tag, manager_id):
     Project = env['project.project']
     existing_projects = Project.search([('name', 'in', NEW_AREA_PROJECT_NAMES)])
     existing_by_name = {project.name: project for project in existing_projects}
@@ -121,20 +132,23 @@ def _create_or_align_new_area_projects(env, area_tag, transversal_tag):
                 'date_start': NEW_PROJECT_START_DATE,
                 'date': False,
                 'allow_timesheets': True,
-                'user_id': NEW_PROJECT_MANAGER_ID,
             }
+            if manager_id:
+                vals['user_id'] = manager_id
             if commands:
                 vals['tag_ids'] = commands
             project.write(vals)
             continue
 
-        to_create.append({
+        vals = {
             'name': name,
             'allow_timesheets': True,
             'date_start': NEW_PROJECT_START_DATE,
-            'user_id': NEW_PROJECT_MANAGER_ID,
             'tag_ids': [(6, 0, [area_tag.id])],
-        })
+        }
+        if manager_id:
+            vals['user_id'] = manager_id
+        to_create.append(vals)
 
     if to_create:
         _logger.info("Creating %s new area projects", len(to_create))
@@ -146,8 +160,9 @@ def migrate(cr, version):
     area_tag = env.ref('somenergia_custom.som_project_tag_area')
     transversal_tag = env.ref('somenergia_custom.som_project_tag_transversal_project')
     excluded_project = env.ref('somenergia_custom.som_cumulative_hours_project', raise_if_not_found=False)
+    manager_id = _get_new_project_manager_id(env)
 
     _logger.info("Applying project validity rollout migration 16.0.1.1.0")
     _close_legacy_projects(env, area_tag, transversal_tag, excluded_project)
-    _create_or_align_new_area_projects(env, area_tag, transversal_tag)
+    _create_or_align_new_area_projects(env, area_tag, transversal_tag, manager_id)
     _logger.info("Project validity rollout migration finished")

--- a/somenergia_custom/migrations/16.0.1.1.0/post-migrate.py
+++ b/somenergia_custom/migrations/16.0.1.1.0/post-migrate.py
@@ -6,8 +6,8 @@ from odoo.api import Environment, SUPERUSER_ID
 _logger = logging.getLogger(__name__)
 
 
-OLD_PROJECT_END_DATE = '2026-07-10'
-NEW_PROJECT_START_DATE = '2026-07-13'
+OLD_PROJECT_END_DATE = '2026-07-05'
+NEW_PROJECT_START_DATE = '2026-07-06'
 NEW_PROJECT_MANAGER_ID = 281
 NEW_AREA_PROJECT_NAMES = [
     'Trobades ET',
@@ -76,7 +76,7 @@ NEW_AREA_PROJECT_NAMES = [
     'Assemblea General',
     'Gran Conversa',
     'Trobada Sòcies Activistes',
-    'Parcicipació sòcies',
+    'Participació sòcies',
     'Formació a les sòcies',
     'Lobby',
     'Representació intercoop',

--- a/somenergia_custom/models/analytic_account.py
+++ b/somenergia_custom/models/analytic_account.py
@@ -142,17 +142,10 @@ class AccountAnalyticLine(models.Model):
                     ) % values['date'])
             # when creating from project.task
             if values.get('task_id'):
-                # We get the project area from employee's department
-                id_employee = values.get('employee_id', False)
-                if id_employee:
-                    employee_id = self.env['hr.employee'].browse(id_employee)
-                    if employee_id.department_id and employee_id.department_id.som_project_area_id:
-                        values['project_id'] = employee_id.department_id.som_project_area_id.id
+                # If the task defines a service project, it takes precedence.
                 task_id = self.env['project.task'].browse(values.get('task_id'))
-
-                # Auto-fill som_additional_project_id based on task's som_additional_project_id
-                if task_id and task_id.som_additional_project_id:
-                    values['som_additional_project_id'] = task_id.som_additional_project_id.id
+                if task_id and task_id.som_project_id:
+                    values['project_id'] = task_id.som_project_id.id
 
                 # Auto-fill som_week_id and som_worked_week_id based on date
                 if values.get('date_time') and not values.get('som_week_id'):

--- a/somenergia_custom/models/analytic_account.py
+++ b/somenergia_custom/models/analytic_account.py
@@ -14,6 +14,9 @@ class AccountAnalyticAccount(models.Model):
 class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
 
+    def _unlink_linked_timesheet(self):
+        self.with_context(skip_linked_timesheet_lock=True).unlink()
+
     @api.depends(
         'som_week_id',
         'som_week_id.som_cw_date',
@@ -131,6 +134,8 @@ class AccountAnalyticLine(models.Model):
 
     def _check_period_lock(self):
         """Raises UserError if any non-cumulative record in self is in a locked period."""
+        if self.env.context.get('skip_linked_timesheet_lock'):
+            return
         company = self.env.company
         for record in self:
             if record.som_is_cumulative or not record.date:
@@ -263,7 +268,7 @@ class AccountAnalyticLine(models.Model):
             # remove linked timesheet
             for record in self:
                 if record.som_timesheet_add_id and record.som_timesheet_add_id.id not in timesheet_ids.ids:
-                    record.som_timesheet_add_id.unlink()
+                    record.som_timesheet_add_id._unlink_linked_timesheet()
 
         return super().write(vals)
 

--- a/somenergia_custom/models/analytic_account.py
+++ b/somenergia_custom/models/analytic_account.py
@@ -192,6 +192,21 @@ class AccountAnalyticLine(models.Model):
     def write(self, vals):
         # Period lock check (skip cumulative lines, they are system-generated)
         self._check_period_lock()
+        # Also check the resulting state: moving to a locked date or a narrower-bypass employee
+        if 'date' in vals or 'employee_id' in vals:
+            company = self.env.company
+            for record in self:
+                if record.som_is_cumulative:
+                    continue
+                new_date = vals.get('date', record.date)
+                new_employee = (
+                    self.env['hr.employee'].browse(vals['employee_id'])
+                    if 'employee_id' in vals else record.employee_id
+                )
+                if new_date and company._is_period_locked(new_date, employee=new_employee):
+                    raise exceptions.UserError(_(
+                        "Cannot move timesheet entry to a locked period (%s)."
+                    ) % new_date)
         if self.task_id and (vals.get('date_time', False) or vals.get('employee_id', False)):
             for record in self:
                 date_time = vals.get('date_time', record.date_time)

--- a/somenergia_custom/models/analytic_account.py
+++ b/somenergia_custom/models/analytic_account.py
@@ -151,7 +151,7 @@ class AccountAnalyticLine(models.Model):
             if record.som_is_cumulative:
                 return False
             if record.som_worked_week_id and record.som_timesheet_add_id:
-                record.som_timesheet_add_id.unlink()
+                record.som_timesheet_add_id._unlink_linked_timesheet()
         return super().unlink()
 
     @api.model_create_multi

--- a/somenergia_custom/models/analytic_account.py
+++ b/somenergia_custom/models/analytic_account.py
@@ -107,7 +107,19 @@ class AccountAnalyticLine(models.Model):
                 if timesheet_week_id and timesheet_add_id:
                     timesheet_week_id.som_timesheet_add_id = timesheet_add_id.id
 
+    def _check_period_lock(self):
+        """Raises UserError if any non-cumulative record in self is in a locked period."""
+        company = self.env.company
+        for record in self:
+            if record.som_is_cumulative or not record.date:
+                continue
+            if company._is_period_locked(record.date, employee=record.employee_id):
+                raise exceptions.UserError(_(
+                    "The timesheet entry dated '%s' belongs to a locked period."
+                ) % record.date)
+
     def unlink(self):
+        self._check_period_lock()
         for record in self:
             if record.som_is_cumulative:
                 return False
@@ -117,8 +129,17 @@ class AccountAnalyticLine(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
+        company = self.env.company
         flag_match = False
         for values in vals_list:
+            # Period lock check (skip cumulative lines, they are system-generated)
+            if not values.get('som_is_cumulative') and values.get('date'):
+                employee = self.env['hr.employee'].browse(values['employee_id']) \
+                    if values.get('employee_id') else self.env['hr.employee']
+                if company._is_period_locked(values['date'], employee=employee):
+                    raise exceptions.UserError(_(
+                        "Cannot create a timesheet entry in a locked period (%s)."
+                    ) % values['date'])
             # when creating from project.task
             if values.get('task_id'):
                 # We get the project area from employee's department
@@ -169,6 +190,8 @@ class AccountAnalyticLine(models.Model):
         return res
 
     def write(self, vals):
+        # Period lock check (skip cumulative lines, they are system-generated)
+        self._check_period_lock()
         if self.task_id and (vals.get('date_time', False) or vals.get('employee_id', False)):
             for record in self:
                 date_time = vals.get('date_time', record.date_time)

--- a/somenergia_custom/models/analytic_account.py
+++ b/somenergia_custom/models/analytic_account.py
@@ -14,6 +14,26 @@ class AccountAnalyticAccount(models.Model):
 class AccountAnalyticLine(models.Model):
     _inherit = "account.analytic.line"
 
+    @api.depends(
+        'som_week_id',
+        'som_week_id.som_cw_date',
+        'som_worked_week_id',
+        'som_worked_week_id.som_cw_date_rel')
+    def _compute_project_area_domain_ids(self):
+        project_domain_helper = self.env['som.common.project']
+        for record in self:
+            reference_date = False
+            if record.som_week_id and record.som_week_id.som_cw_date:
+                reference_date = fields.Date.to_date(record.som_week_id.som_cw_date)
+            elif record.som_worked_week_id and record.som_worked_week_id.som_cw_date_rel:
+                reference_date = fields.Date.to_date(record.som_worked_week_id.som_cw_date_rel)
+
+            project_area_ids, project_transversal_ids = (
+                project_domain_helper._get_project_type_domain_ids(reference_date)
+            )
+            record.som_project_area_domain_ids = project_area_ids
+            record.som_additional_project_domain_ids = project_transversal_ids
+
     name = fields.Char(
         default="/"
     )
@@ -34,11 +54,13 @@ class AccountAnalyticLine(models.Model):
 
     som_project_area_domain_ids = fields.Many2many(
         "project.project",
+        compute="_compute_project_area_domain_ids",
         store=False,
     )
 
     som_additional_project_domain_ids = fields.Many2many(
         "project.project",
+        compute="_compute_project_area_domain_ids",
         store=False,
     )
 

--- a/somenergia_custom/models/hr_employee.py
+++ b/somenergia_custom/models/hr_employee.py
@@ -120,6 +120,14 @@ class HrEmployeeBase(models.AbstractModel):
         string='Disabled restrictions for attendance to date',
     )
 
+    som_lock_bypass_date_from = fields.Date(
+        string='Timesheet lock bypass from',
+    )
+
+    som_lock_bypass_date_to = fields.Date(
+        string='Timesheet lock bypass to',
+    )
+
     som_manager_ids = fields.Many2many(
         string='Managers',
         comodel_name='hr.employee',

--- a/somenergia_custom/models/project_task.py
+++ b/somenergia_custom/models/project_task.py
@@ -64,12 +64,25 @@ class Task(models.Model):
         return result
 
     def write(self, vals):
+        if 'som_project_id' in vals:
+            id_new_service_project = vals.get('som_project_id', False)
+            for task_id in self:
+                current_service_project = task_id.som_project_id
+                flag_changing_som_project_id = current_service_project.id != id_new_service_project
+                timesheet_with_current_service_project_ids = task_id.timesheet_ids.filtered(
+                    lambda x: x.project_id.id == current_service_project.id
+                )
+                if flag_changing_som_project_id and timesheet_with_current_service_project_ids:
+                    raise ValidationError(_(
+                        "No pots modificar la 'Tasca Servei' d'aquesta tasca perquè ja hi ha "
+                        "parts d'hores vinculats."
+                    ))
+
         # we don't allow to change 'som_additional_project_id'
         # if the task has timesheet lines linked to it
         # to avoid inconsistencies in the timesheet entries
         if 'som_additional_project_id' in vals:
             id_new_ap = vals.get('som_additional_project_id', False)
-            timesheet_line_obj = self.env['account.analytic.line']
             for task_id in self:
                 current_ap_id = task_id.som_additional_project_id
                 flag_changing_som_additional_project_id = (

--- a/somenergia_custom/models/res_company.py
+++ b/somenergia_custom/models/res_company.py
@@ -1,5 +1,9 @@
 # -*- coding: utf-8 -*-
+import logging
+from datetime import timedelta
 from odoo import api, fields, models, _
+
+_logger = logging.getLogger(__name__)
 
 
 class ResCompany(models.Model):
@@ -32,3 +36,55 @@ class ResCompany(models.Model):
     som_attendance_limit_checkout = fields.Float(
         digits=(2, 2), default=22.0
     )
+
+    som_timesheet_lock_date = fields.Date(
+        string="Timesheet lock date",
+    )
+
+    som_timesheet_lock_bypass_date_from = fields.Date(
+        string="Global bypass from",
+    )
+
+    som_timesheet_lock_bypass_date_to = fields.Date(
+        string="Global bypass to",
+    )
+
+    def _is_period_locked(self, date_to_check, employee=None):
+        """Returns True if date_to_check falls within a locked period.
+
+        Managers are always allowed.
+        Global bypass and per-employee bypass use date ranges (both dates must be set).
+        date_to_check can be a date, datetime or 'YYYY-MM-DD' string.
+        """
+        self.ensure_one()
+        if not self.som_timesheet_lock_date:
+            return False
+        if self.env.user.has_group('hr_timesheet.group_timesheet_manager'):
+            return False
+        # Normalize date_to_check
+        if isinstance(date_to_check, str):
+            date_to_check = fields.Date.from_string(date_to_check)
+        elif hasattr(date_to_check, 'date'):
+            date_to_check = date_to_check.date()
+        # Global bypass: active only if both dates are set and date falls within range
+        bypass_from = self.som_timesheet_lock_bypass_date_from
+        bypass_to = self.som_timesheet_lock_bypass_date_to
+        if bypass_from and bypass_to and bypass_from <= date_to_check <= bypass_to:
+            return False
+        # Per-employee bypass: same logic
+        if employee:
+            emp_bypass_from = employee.som_lock_bypass_date_from
+            emp_bypass_to = employee.som_lock_bypass_date_to
+            if emp_bypass_from and emp_bypass_to and emp_bypass_from <= date_to_check <= emp_bypass_to:
+                return False
+        return date_to_check <= self.som_timesheet_lock_date
+
+    @api.model
+    def _do_update_timesheet_lock_date(self):
+        """Cron: estableix la data de tancament a l'últim dia del mes anterior."""
+        first_day_current = fields.Date.today().replace(day=1)
+        last_day_prev = first_day_current - timedelta(days=1)
+        companies = self.sudo().search([])
+        for company in companies:
+            company.sudo().som_timesheet_lock_date = last_day_prev
+        _logger.info("Timesheet lock date updated to %s", last_day_prev)

--- a/somenergia_custom/models/res_config_settings.py
+++ b/somenergia_custom/models/res_config_settings.py
@@ -34,3 +34,18 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.som_attendance_limit_checkout',
         readonly=False,
     )
+
+    som_timesheet_lock_date = fields.Date(
+        related='company_id.som_timesheet_lock_date',
+        readonly=False,
+    )
+
+    som_timesheet_lock_bypass_date_from = fields.Date(
+        related='company_id.som_timesheet_lock_bypass_date_from',
+        readonly=False,
+    )
+
+    som_timesheet_lock_bypass_date_to = fields.Date(
+        related='company_id.som_timesheet_lock_bypass_date_to',
+        readonly=False,
+    )

--- a/somenergia_custom/models/res_config_settings.py
+++ b/somenergia_custom/models/res_config_settings.py
@@ -5,6 +5,11 @@ from odoo import api, fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
+    som_worked_week_help_url = fields.Char(
+        string='Worked week help URL',
+        config_parameter='somenergia_custom.som_worked_week_help_url',
+    )
+
     som_restrictive_stress_days = fields.Boolean(
         related='company_id.som_restrictive_stress_days',
         readonly=False,

--- a/somenergia_custom/models/som_common_project.py
+++ b/somenergia_custom/models/som_common_project.py
@@ -9,16 +9,16 @@ class SomCommonProject(models.AbstractModel):
     _description = 'Som Common Project'
 
     def _get_project_type_domain_ids(self, reference_date=False):
+        reference_date = reference_date or fields.Date.today()
         tag_area_id = self.env.ref("somenergia_custom.som_project_tag_area")
         tag_transversal_id = self.env.ref("somenergia_custom.som_project_tag_transversal_project")
 
         area_domain = [("tag_ids", "in", tag_area_id.ids)]
         transversal_domain = [("tag_ids", "in", tag_transversal_id.ids)]
-        if reference_date:
-            area_domain += [
-                '|', ('date_start', '=', False), ('date_start', '<=', reference_date),
-                '|', ('date', '=', False), ('date', '>=', reference_date),
-            ]
+        area_domain += [
+            '|', ('date_start', '=', False), ('date_start', '<=', reference_date),
+            '|', ('date', '=', False), ('date', '>=', reference_date),
+        ]
 
         project_area_ids = self.env['project.project'].search(area_domain)
         project_transversal_ids = self.env['project.project'].search(transversal_domain)

--- a/somenergia_custom/models/som_common_project.py
+++ b/somenergia_custom/models/som_common_project.py
@@ -8,15 +8,25 @@ class SomCommonProject(models.AbstractModel):
     _name = 'som.common.project'
     _description = 'Som Common Project'
 
-    def _compute_project_type_domain_ids(self):
+    def _get_project_type_domain_ids(self, reference_date=False):
         tag_area_id = self.env.ref("somenergia_custom.som_project_tag_area")
         tag_transversal_id = self.env.ref("somenergia_custom.som_project_tag_transversal_project")
-        for record in self:
-            domain = [("tag_ids", "in", tag_area_id.ids)]
-            domain_no_area = [("tag_ids", "in", tag_transversal_id.ids)]
 
-            project_area_ids = self.env['project.project'].search(domain)
-            project_transversal_ids = self.env['project.project'].search(domain_no_area)
+        area_domain = [("tag_ids", "in", tag_area_id.ids)]
+        transversal_domain = [("tag_ids", "in", tag_transversal_id.ids)]
+        if reference_date:
+            area_domain += [
+                '|', ('date_start', '=', False), ('date_start', '<=', reference_date),
+                '|', ('date', '=', False), ('date', '>=', reference_date),
+            ]
+
+        project_area_ids = self.env['project.project'].search(area_domain)
+        project_transversal_ids = self.env['project.project'].search(transversal_domain)
+        return project_area_ids, project_transversal_ids
+
+    def _compute_project_type_domain_ids(self):
+        for record in self:
+            project_area_ids, project_transversal_ids = record._get_project_type_domain_ids()
 
             record.som_project_area_domain_ids = project_area_ids
             record.som_additional_project_domain_ids = project_transversal_ids

--- a/somenergia_custom/models/som_common_project.py
+++ b/somenergia_custom/models/som_common_project.py
@@ -15,10 +15,13 @@ class SomCommonProject(models.AbstractModel):
 
         area_domain = [("tag_ids", "in", tag_area_id.ids)]
         transversal_domain = [("tag_ids", "in", tag_transversal_id.ids)]
-        area_domain += [
+        date_domain = [
             '|', ('date_start', '=', False), ('date_start', '<=', reference_date),
             '|', ('date', '=', False), ('date', '>=', reference_date),
         ]
+
+        area_domain += date_domain
+        transversal_domain += date_domain
 
         project_area_ids = self.env['project.project'].search(area_domain)
         project_transversal_ids = self.env['project.project'].search(transversal_domain)

--- a/somenergia_custom/models/som_worked_week.py
+++ b/somenergia_custom/models/som_worked_week.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, exceptions, _
 from datetime import datetime, timedelta
 
 _logger = logging.getLogger(__name__)
@@ -106,6 +106,35 @@ class SomWorkedWeek(models.Model):
     )
 
     # -----
+
+    @api.depends('som_cw_date_end_rel')
+    def _compute_is_locked(self):
+        company = self.env.company
+        for record in self:
+            date_end = record.som_cw_date_end_rel
+            record.som_is_locked = bool(
+                date_end and company._is_period_locked(date_end, employee=record.som_employee_id)
+            )
+
+    som_is_locked = fields.Boolean(
+        string="Period locked",
+        compute='_compute_is_locked',
+        store=False,
+    )
+
+    def _check_period_lock(self):
+        """Raises UserError if any record in self belongs to a locked period."""
+        company = self.env.company
+        for record in self:
+            date_end = record.som_cw_date_end_rel
+            if date_end and company._is_period_locked(date_end, employee=record.som_employee_id):
+                raise exceptions.UserError(_(
+                    "The worked week '%s' belongs to a locked period and cannot be modified."
+                ) % record.name)
+
+    def write(self, vals):
+        self._check_period_lock()
+        return super().write(vals)
 
     def get_incomplete_worked_weeks(self):
         reference_day = datetime.now() - timedelta(days=datetime.now().weekday() + 1)

--- a/somenergia_custom/models/som_worked_week.py
+++ b/somenergia_custom/models/som_worked_week.py
@@ -12,6 +12,14 @@ class SomWorkedWeek(models.Model):
     _inherit = ["som.common.project", "mail.thread", "mail.activity.mixin"]
     _description = "Som Worked Week"
 
+    @api.depends('som_cw_date_rel')
+    def _compute_project_type_domain_ids(self):
+        for record in self:
+            reference_date = fields.Date.to_date(record.som_cw_date_rel) if record.som_cw_date_rel else False
+            project_area_ids, project_transversal_ids = record._get_project_type_domain_ids(reference_date)
+            record.som_project_area_domain_ids = project_area_ids
+            record.som_additional_project_domain_ids = project_transversal_ids
+
     @api.depends('som_timesheet_ids', 'som_timesheet_ids.unit_amount')
     def _compute_totals(self):
         for record in self:

--- a/somenergia_custom/models/som_worked_week.py
+++ b/somenergia_custom/models/som_worked_week.py
@@ -136,6 +136,21 @@ class SomWorkedWeek(models.Model):
         self._check_period_lock()
         return super().write(vals)
 
+    def action_open_help_url(self):
+        self.ensure_one()
+        help_url = self.env['ir.config_parameter'].sudo().get_param(
+            'somenergia_custom.som_worked_week_help_url'
+        )
+        if not help_url:
+            raise exceptions.UserError(_(
+                "No help URL is configured for worked weeks."
+            ))
+        return {
+            'type': 'ir.actions.act_url',
+            'url': help_url,
+            'target': 'new',
+        }
+
     def get_incomplete_worked_weeks(self):
         reference_day = datetime.now() - timedelta(days=datetime.now().weekday() + 1)
         domain = [

--- a/somenergia_custom/security/hr_timesheet_security.xml
+++ b/somenergia_custom/security/hr_timesheet_security.xml
@@ -34,7 +34,7 @@
                     ('project_id.privacy_visibility', '!=', 'followers'),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                     ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.user_ids', 'in', user.id)
+                    ('task_id.user_ids', 'in', [user.id])
             ]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="False"/>
@@ -52,7 +52,7 @@
                     ('project_id.privacy_visibility', '!=', 'followers'),
                     ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
                     ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
-                    ('task_id.user_ids', 'in', user.id)
+                    ('task_id.user_ids', 'in', [user.id])
             ]</field>
             <field name="perm_read" eval="True"/>
             <field name="perm_write" eval="False"/>

--- a/somenergia_custom/security/hr_timesheet_security.xml
+++ b/somenergia_custom/security/hr_timesheet_security.xml
@@ -9,6 +9,12 @@
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 
+        <record id="som_group_hr_timesheet_visible_projects" model="res.groups">
+            <field name="name">User: visible projects timesheets</field>
+            <field name="category_id" ref="base.module_category_services_timesheets"/>
+            <field name="implied_ids" eval="[(4, ref('hr_timesheet.group_hr_timesheet_user'))]"/>
+        </record>
+
         <record id="som_timesheet_analysis_report_department" model="ir.rule">
             <field name="name">Som Timesheets Analysis Report department</field>
             <field name="model_id" ref="hr_timesheet.model_timesheets_analysis_report"/>
@@ -17,6 +23,42 @@
                 ]
             </field>
             <field name="groups" eval="[(4, ref('som_group_hr_timesheet_department'))]"/>
+        </record>
+
+        <record id="som_timesheet_line_visible_projects_read" model="ir.rule">
+            <field name="name">Som Timesheet line visible projects read</field>
+            <field name="model_id" ref="analytic.model_account_analytic_line"/>
+            <field name="domain_force">[
+                ('project_id', '!=', False),
+                '|', '|', '|',
+                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.user_ids', 'in', user.id)
+            ]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="groups" eval="[(4, ref('som_group_hr_timesheet_visible_projects'))]"/>
+        </record>
+
+        <record id="som_timesheet_analysis_report_visible_projects_read" model="ir.rule">
+            <field name="name">Som Timesheets Analysis Report visible projects read</field>
+            <field name="model_id" ref="hr_timesheet.model_timesheets_analysis_report"/>
+            <field name="domain_force">[
+                ('project_id', '!=', False),
+                '|', '|', '|',
+                    ('project_id.privacy_visibility', '!=', 'followers'),
+                    ('project_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.message_partner_ids', 'in', [user.partner_id.id]),
+                    ('task_id.user_ids', 'in', user.id)
+            ]</field>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+            <field name="groups" eval="[(4, ref('som_group_hr_timesheet_visible_projects'))]"/>
         </record>
 
     </data>

--- a/somenergia_custom/tests/__init__.py
+++ b/somenergia_custom/tests/__init__.py
@@ -11,4 +11,5 @@ from . import test_hr_appraisal
 from . import test_timesheets_analysis
 from . import test_timesheet_visible_projects
 from . import test_analytic_account_line
+from . import test_project_task
 from . import test_timesheet_period_lock

--- a/somenergia_custom/tests/__init__.py
+++ b/somenergia_custom/tests/__init__.py
@@ -9,5 +9,6 @@ from . import test_hr_attendance_hours_limit
 from . import test_hr_employee
 from . import test_hr_appraisal
 from . import test_timesheets_analysis
+from . import test_timesheet_visible_projects
 from . import test_analytic_account_line
 from . import test_timesheet_period_lock

--- a/somenergia_custom/tests/__init__.py
+++ b/somenergia_custom/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_hr_employee
 from . import test_hr_appraisal
 from . import test_timesheets_analysis
 from . import test_analytic_account_line
+from . import test_timesheet_period_lock

--- a/somenergia_custom/tests/test_analytic_account_line.py
+++ b/somenergia_custom/tests/test_analytic_account_line.py
@@ -405,3 +405,124 @@ class TestAnalyticAccountLine(TransactionCase):
             self.project_service.id,
             "writing the same som_project_id should not be blocked"
         )
+
+    def test_worked_week_project_domain_uses_week_start_date(self):
+        area_tag = self.env.ref('somenergia_custom.som_project_tag_area')
+        old_project = self.env['project.project'].create({
+            'name': 'Old Area Project',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date': fields.Date.to_date(self.test_date) - timedelta(days=1),
+        })
+        current_project = self.env['project.project'].create({
+            'name': 'Current Area Project',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date),
+        })
+        future_project = self.env['project.project'].create({
+            'name': 'Future Area Project',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date) + timedelta(days=7),
+        })
+
+        self.worked_week._compute_project_type_domain_ids()
+
+        self.assertNotIn(old_project, self.worked_week.som_project_area_domain_ids)
+        self.assertIn(current_project, self.worked_week.som_project_area_domain_ids)
+        self.assertNotIn(future_project, self.worked_week.som_project_area_domain_ids)
+
+    def test_timesheet_project_domain_uses_week_start_date(self):
+        area_tag = self.env.ref('somenergia_custom.som_project_tag_area')
+        old_project = self.env['project.project'].create({
+            'name': 'Old Area Project Line',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date': fields.Date.to_date(self.test_date) - timedelta(days=1),
+        })
+        current_project = self.env['project.project'].create({
+            'name': 'Current Area Project Line',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date),
+        })
+        future_project = self.env['project.project'].create({
+            'name': 'Future Area Project Line',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date) + timedelta(days=7),
+        })
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Week Based Domain',
+            'project_id': self.project_main.id,
+            'employee_id': self.employee.id,
+            'date': fields.Date.to_date(self.test_date),
+            'som_week_id': self.calendar_week.id,
+            'unit_amount': 1.0,
+        })
+
+        self.assertNotIn(old_project, timesheet.som_project_area_domain_ids)
+        self.assertIn(current_project, timesheet.som_project_area_domain_ids)
+        self.assertNotIn(future_project, timesheet.som_project_area_domain_ids)
+
+    def test_worked_week_project_domain_includes_projects_without_dates(self):
+        area_tag = self.env.ref('somenergia_custom.som_project_tag_area')
+        timeless_project = self.env['project.project'].create({
+            'name': 'Timeless Area Project',
+            'tag_ids': [(6, 0, [area_tag.id])],
+        })
+
+        self.worked_week._compute_project_type_domain_ids()
+
+        self.assertIn(timeless_project, self.worked_week.som_project_area_domain_ids)
+
+    def test_worked_week_project_domain_date_start_is_inclusive(self):
+        area_tag = self.env.ref('somenergia_custom.som_project_tag_area')
+        starts_this_week = self.env['project.project'].create({
+            'name': 'Starts This Week',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date),
+        })
+
+        self.worked_week._compute_project_type_domain_ids()
+
+        self.assertIn(starts_this_week, self.worked_week.som_project_area_domain_ids)
+
+    def test_worked_week_project_domain_end_date_is_inclusive(self):
+        area_tag = self.env.ref('somenergia_custom.som_project_tag_area')
+        ends_this_week = self.env['project.project'].create({
+            'name': 'Ends This Week',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date': fields.Date.to_date(self.test_date),
+        })
+        ended_before_week = self.env['project.project'].create({
+            'name': 'Ended Before Week',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date': fields.Date.to_date(self.test_date) - timedelta(days=1),
+        })
+
+        self.worked_week._compute_project_type_domain_ids()
+
+        self.assertIn(ends_this_week, self.worked_week.som_project_area_domain_ids)
+        self.assertNotIn(ended_before_week, self.worked_week.som_project_area_domain_ids)
+
+    def test_timesheet_project_domain_falls_back_to_worked_week_start_date(self):
+        area_tag = self.env.ref('somenergia_custom.som_project_tag_area')
+        old_project = self.env['project.project'].create({
+            'name': 'Old Area Project Fallback',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date': fields.Date.to_date(self.test_date) - timedelta(days=1),
+        })
+        current_project = self.env['project.project'].create({
+            'name': 'Current Area Project Fallback',
+            'tag_ids': [(6, 0, [area_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date),
+        })
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Worked Week Fallback Domain',
+            'project_id': self.project_main.id,
+            'employee_id': self.employee.id,
+            'date': fields.Date.to_date(self.test_date),
+            'som_worked_week_id': self.worked_week.id,
+            'unit_amount': 1.0,
+        })
+
+        self.assertNotIn(old_project, timesheet.som_project_area_domain_ids)
+        self.assertIn(current_project, timesheet.som_project_area_domain_ids)

--- a/somenergia_custom/tests/test_analytic_account_line.py
+++ b/somenergia_custom/tests/test_analytic_account_line.py
@@ -526,3 +526,58 @@ class TestAnalyticAccountLine(TransactionCase):
 
         self.assertNotIn(old_project, timesheet.som_project_area_domain_ids)
         self.assertIn(current_project, timesheet.som_project_area_domain_ids)
+
+    def test_worked_week_transversal_domain_uses_week_start_date(self):
+        transversal_tag = self.env.ref('somenergia_custom.som_project_tag_transversal_project')
+        old_project = self.env['project.project'].create({
+            'name': 'Old Transversal Project',
+            'tag_ids': [(6, 0, [transversal_tag.id])],
+            'date': fields.Date.to_date(self.test_date) - timedelta(days=1),
+        })
+        current_project = self.env['project.project'].create({
+            'name': 'Current Transversal Project',
+            'tag_ids': [(6, 0, [transversal_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date),
+        })
+        future_project = self.env['project.project'].create({
+            'name': 'Future Transversal Project',
+            'tag_ids': [(6, 0, [transversal_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date) + timedelta(days=7),
+        })
+
+        self.worked_week._compute_project_type_domain_ids()
+
+        self.assertNotIn(old_project, self.worked_week.som_additional_project_domain_ids)
+        self.assertIn(current_project, self.worked_week.som_additional_project_domain_ids)
+        self.assertNotIn(future_project, self.worked_week.som_additional_project_domain_ids)
+
+    def test_timesheet_transversal_domain_uses_week_start_date(self):
+        transversal_tag = self.env.ref('somenergia_custom.som_project_tag_transversal_project')
+        old_project = self.env['project.project'].create({
+            'name': 'Old Transversal Project Line',
+            'tag_ids': [(6, 0, [transversal_tag.id])],
+            'date': fields.Date.to_date(self.test_date) - timedelta(days=1),
+        })
+        current_project = self.env['project.project'].create({
+            'name': 'Current Transversal Project Line',
+            'tag_ids': [(6, 0, [transversal_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date),
+        })
+        future_project = self.env['project.project'].create({
+            'name': 'Future Transversal Project Line',
+            'tag_ids': [(6, 0, [transversal_tag.id])],
+            'date_start': fields.Date.to_date(self.test_date) + timedelta(days=7),
+        })
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Week Based Transversal Domain',
+            'project_id': self.project_main.id,
+            'employee_id': self.employee.id,
+            'date': fields.Date.to_date(self.test_date),
+            'som_week_id': self.calendar_week.id,
+            'unit_amount': 1.0,
+        })
+
+        self.assertNotIn(old_project, timesheet.som_additional_project_domain_ids)
+        self.assertIn(current_project, timesheet.som_additional_project_domain_ids)
+        self.assertNotIn(future_project, timesheet.som_additional_project_domain_ids)

--- a/somenergia_custom/tests/test_analytic_account_line.py
+++ b/somenergia_custom/tests/test_analytic_account_line.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import fields
+from odoo.exceptions import ValidationError
 from odoo.tests.common import tagged, TransactionCase
 from datetime import datetime, timedelta
 
@@ -15,11 +16,10 @@ class TestAnalyticAccountLine(TransactionCase):
             'name': 'Test Department',
         })
 
-        # Create project area for the department
-        cls.project_area = cls.env['project.project'].create({
-            'name': 'Test Project Area',
+        # Create service project used by task timesheets
+        cls.project_service = cls.env['project.project'].create({
+            'name': 'Test Service Project',
         })
-        cls.department.som_project_area_id = cls.project_area.id
 
         # Create employee
         cls.employee = cls.env['hr.employee'].create({
@@ -31,14 +31,12 @@ class TestAnalyticAccountLine(TransactionCase):
         cls.project_main = cls.env['project.project'].create({
             'name': 'Main Project',
         })
-        cls.project_transversal = cls.env['project.project'].create({
-            'name': 'Transversal Project',
-        })
 
         # Create task
         cls.task = cls.env['project.task'].create({
             'name': 'Test Task',
             'project_id': cls.project_main.id,
+            'som_project_id': cls.project_service.id,
         })
 
         # Create a calendar week
@@ -114,8 +112,8 @@ class TestAnalyticAccountLine(TransactionCase):
             "Both timesheets in same week should share the same worked_week"
         )
 
-    def test_create_timesheet_sets_project_from_department_area(self):
-        """Test that project_id is set from employee's department project area"""
+    def test_create_timesheet_sets_project_from_task_service_project(self):
+        """Test that project_id is set from the task service project."""
         timesheet = self.env['account.analytic.line'].create({
             'name': 'Test Timesheet',
             'task_id': self.task.id,
@@ -126,16 +124,12 @@ class TestAnalyticAccountLine(TransactionCase):
 
         self.assertEqual(
             timesheet.project_id.id,
-            self.project_area.id,
-            "project_id should be set from employee's department project area"
+            self.project_service.id,
+            "project_id should be set from the task service project"
         )
 
-    def test_create_timesheet_with_additional_project(self):
-        """Test creating timesheet with som_additional_project_id creates linked timesheet"""
-        # Set additional project on task
-        self.task.write({'som_additional_project_id': self.project_transversal.id})
-
-        timesheet_ids = self.env['account.analytic.line'].create({
+    def test_create_timesheet_overrides_incoming_project_with_task_service_project(self):
+        timesheet = self.env['account.analytic.line'].create({
             'name': 'Test Timesheet',
             'task_id': self.task.id,
             'project_id': self.project_main.id,
@@ -145,65 +139,27 @@ class TestAnalyticAccountLine(TransactionCase):
         })
 
         self.assertEqual(
-            len(timesheet_ids),
-            2,
-            "Creating timesheet with som_additional_project_id should create 2 timesheets"
+            timesheet.project_id.id,
+            self.project_service.id,
+            "task service project should take precedence over the provided project_id"
         )
 
-        timesheets_project_area_id = timesheet_ids.filtered(
-            lambda x: x.project_id.id == self.department.som_project_area_id.id)
+    def test_create_timesheet_without_task_service_project_keeps_given_project(self):
+        self.task.som_project_id = False
 
-        self.assertTrue(
-            timesheets_project_area_id,
-            "One of the timesheets should be linked to the department's project area"
-        )
-        self.assertEqual(
-            timesheets_project_area_id.project_id.id,
-            self.department.som_project_area_id.id,
-            "One of the timesheets should be linked to the department's project area"
-        )
-        self.assertEqual(
-            timesheets_project_area_id.som_additional_project_id.id,
-            self.project_transversal.id,
-            "The timesheet linked to the project area should have "
-            "the transversal project as additional project"
-        )
-
-        timesheet_additional_id = timesheet_ids.filtered(
-            lambda x: x.project_id.id == self.project_transversal.id)
-
-        self.assertTrue(
-            timesheet_additional_id,
-            "One of the timesheets should be linked to the transversal project"
-        )
-        self.assertEqual(
-            timesheet_additional_id.project_id.id,
-            self.project_transversal.id,
-            "One of the timesheets should be linked to the transversal project"
-        )
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Timesheet',
+            'task_id': self.task.id,
+            'project_id': self.project_main.id,
+            'employee_id': self.employee.id,
+            'date_time': self.test_date,
+            'unit_amount': 2.0,
+        })
 
         self.assertEqual(
-            timesheet_additional_id.unit_amount,
-            2.0,
-            "The timesheet linked to the transversal project should have "
-            "the same hours as the main timesheet"
-        )
-
-        # # Verify UUID hook is set
-        self.assertTrue(
-            timesheets_project_area_id.som_timesheet_uuid_hook,
-            "UUID hook should be set on the timesheet linked to the project area"
-        )
-
-        self.assertTrue(
-            timesheet_additional_id.som_timesheet_uuid_hook,
-            "UUID hook should be set on the timesheet linked to the transversal project"
-        )
-
-        self.assertEqual(
-            timesheets_project_area_id.som_timesheet_uuid_hook,
-            timesheet_additional_id.som_timesheet_uuid_hook,
-            "Both timesheets should share the same UUID hook"
+            timesheet.project_id.id,
+            self.project_main.id,
+            "Timesheets should keep the provided project when the task has no service project"
         )
 
     def test_write_timesheet_updates_week_when_date_changes(self):
@@ -267,132 +223,6 @@ class TestAnalyticAccountLine(TransactionCase):
             timesheet.som_worked_week_id.id,
             initial_worked_week_id,
             "som_worked_week_id should be updated to new worked week"
-        )
-
-    def test_write_timesheet_updates_linked_hours(self):
-        """Test that updating hours also updates linked timesheet"""
-        # Set additional project on task
-        self.task.som_additional_project_id = self.project_transversal.id
-
-        timesheet = self.env['account.analytic.line'].create({
-            'name': 'Test Timesheet',
-            'task_id': self.task.id,
-            'project_id': self.project_main.id,
-            'employee_id': self.employee.id,
-            'date_time': self.test_date,
-            'unit_amount': 2.0,
-        })
-
-        linked_timesheet = timesheet.som_timesheet_add_id
-
-        # Update hours
-        timesheet.write({
-            'unit_amount': 5.0,
-        })
-
-        self.assertEqual(
-            linked_timesheet.unit_amount,
-            5.0,
-            "Linked timesheet hours should be updated"
-        )
-
-    def test_write_add_additional_project_creates_link(self):
-        """Test adding som_additional_project_id creates linked timesheet"""
-        timesheet = self.env['account.analytic.line'].create({
-            'name': 'Test Timesheet',
-            'task_id': self.task.id,
-            'project_id': self.project_main.id,
-            'employee_id': self.employee.id,
-            'date_time': self.test_date,
-            'unit_amount': 2.0,
-        })
-
-        self.assertFalse(
-            timesheet.som_timesheet_add_id,
-            "No linked timesheet should exist initially"
-        )
-
-        # Add additional project
-        timesheet.write({
-            'som_additional_project_id': self.project_transversal.id,
-        })
-
-        self.assertTrue(
-            timesheet.som_timesheet_add_id,
-            "Linked timesheet should be created"
-        )
-        self.assertEqual(
-            timesheet.som_timesheet_add_id.project_id.id,
-            self.project_transversal.id,
-            "Linked timesheet should have the transversal project"
-        )
-
-    def test_write_change_additional_project_updates_link(self):
-        """Test changing som_additional_project_id updates linked timesheet project"""
-        # Create another transversal project
-        project_transversal_2 = self.env['project.project'].create({
-            'name': 'Transversal Project 2',
-        })
-
-        # Set additional project on task
-        self.task.som_additional_project_id = self.project_transversal.id
-
-        timesheet = self.env['account.analytic.line'].create({
-            'name': 'Test Timesheet',
-            'task_id': self.task.id,
-            'project_id': self.project_main.id,
-            'employee_id': self.employee.id,
-            'date_time': self.test_date,
-            'unit_amount': 2.0,
-        })
-
-        linked_timesheet = timesheet.som_timesheet_add_id
-
-        # Change additional project
-        timesheet.write({
-            'som_additional_project_id': project_transversal_2.id,
-        })
-
-        self.assertEqual(
-            linked_timesheet.project_id.id,
-            project_transversal_2.id,
-            "Linked timesheet project should be updated"
-        )
-
-    def test_write_remove_additional_project_deletes_link(self):
-        """Test removing som_additional_project_id deletes linked timesheet"""
-        # Set additional project on task
-        self.task.som_additional_project_id = self.project_transversal.id
-
-        timesheet_ids = self.env['account.analytic.line'].create({
-            'name': 'Test Timesheet',
-            'task_id': self.task.id,
-            'project_id': self.project_main.id,
-            'employee_id': self.employee.id,
-            'date_time': self.test_date,
-            'unit_amount': 2.0,
-        })
-
-        timesheets_project_area_id = timesheet_ids.filtered(
-            lambda x: x.project_id.id == self.department.som_project_area_id.id)
-
-        timesheet_additional_id = timesheet_ids.filtered(
-            lambda x: x.project_id.id == self.project_transversal.id)
-
-        id_additional_tsh = timesheet_additional_id.id
-
-        # Remove additional project
-        timesheets_project_area_id.write({
-            'som_additional_project_id': False,
-        })
-
-        # Check linked timesheet is deleted
-        deleted = self.env['account.analytic.line'].with_context(active_test=False).search([
-            ('id', '=', id_additional_tsh),
-        ])
-        self.assertFalse(
-            deleted,
-            "Linked timesheet should be deleted"
         )
 
     def test_create_without_task_doesnt_auto_fill(self):
@@ -482,37 +312,96 @@ class TestAnalyticAccountLine(TransactionCase):
             "som_worked_week_id should change to the one of the new employee"
         )
 
-    def test_write_task_change_additional_project_not_allowed(self):
-        """
-        Test that changing task's som_additional_project_id is not allowed
-        when it has timesheets linked
-        """
-        # Set additional project on task
-        self.task.som_additional_project_id = self.project_transversal.id
-        timesheet_ids = self.env['account.analytic.line'].create({
-            'name': 'Test Timesheet',
-            'task_id': self.task.id,
+    def test_create_without_task_keeps_explicit_project(self):
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Test Timesheet Direct',
             'project_id': self.project_main.id,
+            'employee_id': self.employee.id,
+            'date': fields.Date.today(),
+            'unit_amount': 2.0,
+        })
+
+        self.assertEqual(
+            timesheet.project_id.id,
+            self.project_main.id,
+            "Timesheets without task_id should keep the provided project"
+        )
+
+    def test_write_task_service_project_allowed_without_timesheets(self):
+        new_service_project = self.env['project.project'].create({
+            'name': 'New Service Project',
+        })
+
+        self.task.write({
+            'som_project_id': new_service_project.id,
+        })
+
+        self.assertEqual(
+            self.task.som_project_id.id,
+            new_service_project.id,
+            "som_project_id should be updated when there are no linked timesheets"
+        )
+
+    def test_write_task_service_project_allowed_when_timesheets_use_other_project(self):
+        other_service_project = self.env['project.project'].create({
+            'name': 'Other Service Project',
+        })
+        new_service_project = self.env['project.project'].create({
+            'name': 'Replacement Service Project',
+        })
+
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Manual Timesheet',
+            'task_id': self.task.id,
             'employee_id': self.employee.id,
             'date_time': self.test_date,
             'unit_amount': 2.0,
         })
-        # Try to change additional project
-        with self.assertRaises(Exception):
+        timesheet.write({'project_id': other_service_project.id})
+
+        self.task.write({
+            'som_project_id': new_service_project.id,
+        })
+
+        self.assertEqual(
+            self.task.som_project_id.id,
+            new_service_project.id,
+            "som_project_id should be updated when existing timesheets use another project"
+        )
+
+    def test_write_task_service_project_blocked_with_linked_timesheets(self):
+        new_service_project = self.env['project.project'].create({
+            'name': 'Blocked Service Project',
+        })
+
+        self.env['account.analytic.line'].create({
+            'name': 'Service Timesheet',
+            'task_id': self.task.id,
+            'employee_id': self.employee.id,
+            'date_time': self.test_date,
+            'unit_amount': 2.0,
+        })
+
+        with self.assertRaises(ValidationError):
             self.task.write({
-                'som_additional_project_id': False,
+                'som_project_id': new_service_project.id,
             })
 
-    def test_write_task_change_additional_project_allowed(self):
-        """
-        Test that changing task's som_additional_project_id is allowed
-        """
-        # Set additional project on task
-        self.task.som_additional_project_id = self.project_transversal.id
-        self.task.write({
-            'som_additional_project_id': False,
+    def test_write_task_service_project_same_value_is_allowed(self):
+        self.env['account.analytic.line'].create({
+            'name': 'Service Timesheet',
+            'task_id': self.task.id,
+            'employee_id': self.employee.id,
+            'date_time': self.test_date,
+            'unit_amount': 2.0,
         })
-        self.assertFalse(
-            self.task.som_additional_project_id,
-            "som_additional_project_id should be removed successfully after unlinking timesheets"
+
+        self.task.write({
+            'som_project_id': self.project_service.id,
+        })
+
+        self.assertEqual(
+            self.task.som_project_id.id,
+            self.project_service.id,
+            "writing the same som_project_id should not be blocked"
         )

--- a/somenergia_custom/tests/test_hr_employee.py
+++ b/somenergia_custom/tests/test_hr_employee.py
@@ -17,6 +17,8 @@ class TestEmployeeIsPresent(TestHrHolidaysCommon):
     def setUpClass(cls):
         super().setUpClass()
 
+        cls.env.company.som_timesheet_lock_date = False
+
         leave_start_datetime = datetime(2025, 4, 1, 8, 0, 0, 0)
         leave_end_datetime = datetime(2025, 4, 3, 15, 0, 0, 0)
         # leave_end_datetime = leave_start_datetime + relativedelta(days=2)

--- a/somenergia_custom/tests/test_hr_leave_type.py
+++ b/somenergia_custom/tests/test_hr_leave_type.py
@@ -4,16 +4,20 @@ from odoo.addons.mail.tests.common import mail_new_test_user
 from datetime import datetime
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
+from odoo.tests.common import tagged
 
 from odoo.exceptions import UserError, ValidationError
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 
 
+@tagged('som_hr_leave_type')
 class TestHrLeaveType(TestHrHolidaysCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        cls.env.company.som_timesheet_lock_date = False
 
         leave_start_datetime = datetime(2024, 11, 27, 7, 0, 0, 0)
         leave_end_datetime = leave_start_datetime + relativedelta(days=3)

--- a/somenergia_custom/tests/test_project_task.py
+++ b/somenergia_custom/tests/test_project_task.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from datetime import timedelta
+
+from freezegun import freeze_time
+
+from odoo import fields
+from odoo.tests.common import TransactionCase, tagged
+
+
+@tagged('som_project_task')
+class TestProjectTask(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.area_tag = cls.env.ref('somenergia_custom.som_project_tag_area')
+
+    @freeze_time('2026-02-16')
+    def test_task_service_project_domain_uses_current_date_validity(self):
+        today = fields.Date.today()
+        old_project = self.env['project.project'].create({
+            'name': 'Expired Area Project',
+            'tag_ids': [(6, 0, [self.area_tag.id])],
+            'date': today - timedelta(days=1),
+        })
+        current_project = self.env['project.project'].create({
+            'name': 'Current Area Project',
+            'tag_ids': [(6, 0, [self.area_tag.id])],
+            'date_start': today,
+        })
+        future_project = self.env['project.project'].create({
+            'name': 'Future Area Project',
+            'tag_ids': [(6, 0, [self.area_tag.id])],
+            'date_start': today + timedelta(days=7),
+        })
+        timeless_project = self.env['project.project'].create({
+            'name': 'Timeless Area Project',
+            'tag_ids': [(6, 0, [self.area_tag.id])],
+        })
+        non_area_project = self.env['project.project'].create({
+            'name': 'Non Area Project',
+        })
+
+        task = self.env['project.task'].create({
+            'name': 'Task Domain Test',
+            'project_id': timeless_project.id,
+        })
+        task._compute_project_type_domain_ids()
+
+        self.assertNotIn(old_project, task.som_project_area_domain_ids)
+        self.assertIn(current_project, task.som_project_area_domain_ids)
+        self.assertNotIn(future_project, task.som_project_area_domain_ids)
+        self.assertIn(timeless_project, task.som_project_area_domain_ids)
+        self.assertNotIn(non_area_project, task.som_project_area_domain_ids)

--- a/somenergia_custom/tests/test_timesheet_period_lock.py
+++ b/somenergia_custom/tests/test_timesheet_period_lock.py
@@ -281,9 +281,16 @@ class TestTimesheetPeriodLock(TransactionCase):
         ])
         self.assertFalse(linked_line_exists)
 
-    def test_unlink_open_main_line_deletes_linked_locked_line(self):
-        """Deleting an open line can also delete its locked linked transversal line."""
-        main_line = self._make_line(OPEN_DATE)
+    def test_unlink_open_worked_week_line_deletes_linked_locked_line(self):
+        """Deleting an open worked-week line can also delete its locked linked transversal line."""
+        main_line = self.env['account.analytic.line'].create({
+            'name': '/',
+            'project_id': self.project.id,
+            'employee_id': self.employee.id,
+            'date': OPEN_DATE,
+            'unit_amount': 1.0,
+            'som_worked_week_id': self.worked_week_open.id,
+        })
         linked_line = self._make_line(LOCKED_DATE)
         main_line.write({'som_timesheet_add_id': linked_line.id})
 

--- a/somenergia_custom/tests/test_timesheet_period_lock.py
+++ b/somenergia_custom/tests/test_timesheet_period_lock.py
@@ -281,6 +281,19 @@ class TestTimesheetPeriodLock(TransactionCase):
         ])
         self.assertFalse(linked_line_exists)
 
+    def test_unlink_open_main_line_deletes_linked_locked_line(self):
+        """Deleting an open line can also delete its locked linked transversal line."""
+        main_line = self._make_line(OPEN_DATE)
+        linked_line = self._make_line(LOCKED_DATE)
+        main_line.write({'som_timesheet_add_id': linked_line.id})
+
+        main_line.with_user(self.regular_user).sudo().unlink()
+
+        linked_line_exists = self.env['account.analytic.line'].with_context(active_test=False).search([
+            ('id', '=', linked_line.id),
+        ])
+        self.assertFalse(linked_line_exists)
+
     # ── Group 6 — som.worked.week.write() ─────────────────────────────────────
 
     def test_worked_week_write_locked_raises(self):

--- a/somenergia_custom/tests/test_timesheet_period_lock.py
+++ b/somenergia_custom/tests/test_timesheet_period_lock.py
@@ -264,6 +264,23 @@ class TestTimesheetPeriodLock(TransactionCase):
         line = self._make_line(LOCKED_DATE, is_cumulative=True)
         line.unlink()
 
+    def test_remove_additional_project_unlinks_linked_locked_line(self):
+        """Removing transversal link from an open line can delete a locked linked line."""
+        transversal_project = self.env['project.project'].create({'name': 'Transversal Lock Test'})
+        main_line = self._make_line(OPEN_DATE)
+        linked_line = self._make_line(LOCKED_DATE)
+        main_line.write({
+            'som_additional_project_id': transversal_project.id,
+            'som_timesheet_add_id': linked_line.id,
+        })
+
+        main_line.with_user(self.regular_user).sudo().write({'som_additional_project_id': False})
+
+        linked_line_exists = self.env['account.analytic.line'].with_context(active_test=False).search([
+            ('id', '=', linked_line.id),
+        ])
+        self.assertFalse(linked_line_exists)
+
     # ── Group 6 — som.worked.week.write() ─────────────────────────────────────
 
     def test_worked_week_write_locked_raises(self):

--- a/somenergia_custom/tests/test_timesheet_period_lock.py
+++ b/somenergia_custom/tests/test_timesheet_period_lock.py
@@ -1,0 +1,289 @@
+# -*- coding: utf-8 -*-
+from datetime import date, datetime, timedelta
+
+from odoo.tests import new_test_user
+from odoo.tests.common import tagged, TransactionCase
+from odoo.exceptions import UserError
+from odoo.addons.base.tests.common import DISABLED_MAIL_CONTEXT
+
+# ─── Dates used across all tests ──────────────────────────────────────────────
+LOCK_DATE = date(2026, 4, 30)     # lock boundary (inclusive)
+LOCKED_DATE = date(2026, 4, 15)   # date strictly inside the locked period
+OPEN_DATE = date(2026, 5, 10)     # date clearly after the lock boundary
+BYPASS_FROM = date(2026, 4, 1)
+BYPASS_TO = date(2026, 4, 30)
+
+
+@tagged('som_timesheet_period_lock')
+class TestTimesheetPeriodLock(TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.env = cls.env(context=dict(cls.env.context, **DISABLED_MAIL_CONTEXT))
+
+        # Company lock date
+        cls.env.company.som_timesheet_lock_date = LOCK_DATE
+
+        # Users
+        # regular_user: can use timesheets, NOT a timesheet manager
+        cls.regular_user = new_test_user(
+            cls.env,
+            login='timesheet_regular',
+            groups='base.group_user,hr_timesheet.group_hr_timesheet_user',
+        )
+        # manager_user: has the manager group → always bypasses the lock
+        cls.manager_user = new_test_user(
+            cls.env,
+            login='timesheet_manager',
+            groups='base.group_user,hr_timesheet.group_timesheet_manager',
+        )
+
+        # Employees
+        cls.employee = cls.env['hr.employee'].create({'name': 'Regular Employee'})
+        cls.employee_bypass = cls.env['hr.employee'].create({
+            'name': 'Bypass Employee',
+            'som_lock_bypass_date_from': BYPASS_FROM,
+            'som_lock_bypass_date_to': BYPASS_TO,
+        })
+
+        # Project required for account.analytic.line
+        cls.project = cls.env['project.project'].create({'name': 'Lock Test Project'})
+
+        # Calendar weeks
+        cls.week_locked = cls.env['som.calendar.week'].create({
+            'name': '2026-W16',
+            'som_cw_code': '2026W16',
+            'som_cw_date': datetime(2026, 4, 13, 0, 0, 0),
+            'som_cw_date_end': datetime(2026, 4, 19, 23, 59, 59),
+            'som_cw_week_number': 16,
+            'som_cw_week_year': 2026,
+            'som_cw_year': 2026,
+        })
+        cls.week_open = cls.env['som.calendar.week'].create({
+            'name': '2026-W19',
+            'som_cw_code': '2026W19',
+            'som_cw_date': datetime(2026, 5, 4, 0, 0, 0),
+            'som_cw_date_end': datetime(2026, 5, 10, 23, 59, 59),
+            'som_cw_week_number': 19,
+            'som_cw_week_year': 2026,
+            'som_cw_year': 2026,
+        })
+
+        # Worked weeks (pre-loaded by the system, never created by end users)
+        cls.worked_week_locked = cls.env['som.worked.week'].create({
+            'som_week_id': cls.week_locked.id,
+            'som_employee_id': cls.employee.id,
+        })
+        cls.worked_week_open = cls.env['som.worked.week'].create({
+            'som_week_id': cls.week_open.id,
+            'som_employee_id': cls.employee.id,
+        })
+
+    # ── Helper ────────────────────────────────────────────────────────────────
+
+    def _make_line(self, date_val, employee=None, is_cumulative=False):
+        """Create an account.analytic.line as admin (bypasses lock and rules)."""
+        return self.env['account.analytic.line'].create({
+            'name': '/',
+            'project_id': self.project.id,
+            'employee_id': (employee or self.employee).id,
+            'date': date_val,
+            'unit_amount': 1.0,
+            'som_is_cumulative': is_cumulative,
+        })
+
+    # ── Group 1 — res.company._is_period_locked() ─────────────────────────────
+
+    def test_is_period_locked_no_lock_date(self):
+        """Without a lock date configured, nothing is ever locked."""
+        self.env.company.som_timesheet_lock_date = False
+        company = self.env.company.with_user(self.regular_user)
+        self.assertFalse(company._is_period_locked(LOCKED_DATE))
+
+    def test_is_period_locked_manager_bypasses(self):
+        """Timesheet managers are never blocked, even on locked dates."""
+        company = self.env.company.with_user(self.manager_user)
+        self.assertFalse(company._is_period_locked(LOCKED_DATE))
+
+    def test_is_period_locked_date_before_lock(self):
+        """A date strictly before the lock boundary is locked."""
+        company = self.env.company.with_user(self.regular_user)
+        self.assertTrue(company._is_period_locked(LOCKED_DATE))
+
+    def test_is_period_locked_date_at_boundary(self):
+        """The lock date itself is also locked (inclusive boundary)."""
+        company = self.env.company.with_user(self.regular_user)
+        self.assertTrue(company._is_period_locked(LOCK_DATE))
+
+    def test_is_period_locked_date_after_lock(self):
+        """A date after the lock boundary is open."""
+        company = self.env.company.with_user(self.regular_user)
+        self.assertFalse(company._is_period_locked(OPEN_DATE))
+
+    def test_is_period_locked_global_bypass_within(self):
+        """Global bypass range unlocks dates falling within it."""
+        self.env.company.som_timesheet_lock_bypass_date_from = BYPASS_FROM
+        self.env.company.som_timesheet_lock_bypass_date_to = BYPASS_TO
+        company = self.env.company.with_user(self.regular_user)
+        self.assertFalse(company._is_period_locked(LOCKED_DATE))
+
+    def test_is_period_locked_global_bypass_partial(self):
+        """A partial bypass (only 'from', no 'to') does not unlock anything."""
+        self.env.company.som_timesheet_lock_bypass_date_from = BYPASS_FROM
+        self.env.company.som_timesheet_lock_bypass_date_to = False
+        company = self.env.company.with_user(self.regular_user)
+        self.assertTrue(company._is_period_locked(LOCKED_DATE))
+
+    def test_is_period_locked_employee_bypass_within(self):
+        """Per-employee bypass unlocks dates within the employee's bypass range."""
+        company = self.env.company.with_user(self.regular_user)
+        self.assertFalse(
+            company._is_period_locked(LOCKED_DATE, employee=self.employee_bypass)
+        )
+
+    def test_is_period_locked_employee_bypass_outside(self):
+        """A date outside the employee's bypass range remains locked."""
+        company = self.env.company.with_user(self.regular_user)
+        date_outside_bypass = date(2026, 3, 15)  # March — before bypass starts
+        self.assertTrue(
+            company._is_period_locked(date_outside_bypass, employee=self.employee_bypass)
+        )
+
+    # ── Group 2 — account.analytic.line.create() ──────────────────────────────
+
+    def test_create_locked_raises(self):
+        """Creating a timesheet entry in a locked period raises UserError."""
+        with self.assertRaises(UserError):
+            self.env['account.analytic.line'].with_user(self.regular_user).sudo().create({
+                'name': '/',
+                'project_id': self.project.id,
+                'employee_id': self.employee.id,
+                'date': LOCKED_DATE,
+                'unit_amount': 1.0,
+            })
+
+    def test_create_open_ok(self):
+        """Creating a timesheet entry in an open period succeeds."""
+        line = self.env['account.analytic.line'].with_user(self.regular_user).sudo().create({
+            'name': '/',
+            'project_id': self.project.id,
+            'employee_id': self.employee.id,
+            'date': OPEN_DATE,
+            'unit_amount': 1.0,
+        })
+        self.assertTrue(line)
+
+    def test_create_cumulative_locked_ok(self):
+        """System-generated cumulative lines are never blocked by the lock."""
+        line = self._make_line(LOCKED_DATE, is_cumulative=True)
+        self.assertTrue(line)
+
+    def test_create_manager_locked_ok(self):
+        """Timesheet managers can always create entries, even in locked periods."""
+        line = self.env['account.analytic.line'].with_user(self.manager_user).sudo().create({
+            'name': '/',
+            'project_id': self.project.id,
+            'employee_id': self.employee.id,
+            'date': LOCKED_DATE,
+            'unit_amount': 1.0,
+        })
+        self.assertTrue(line)
+
+    def test_create_employee_bypass_ok(self):
+        """Creating an entry for an employee whose bypass covers the date succeeds."""
+        line = self.env['account.analytic.line'].with_user(self.regular_user).sudo().create({
+            'name': '/',
+            'project_id': self.project.id,
+            'employee_id': self.employee_bypass.id,
+            'date': LOCKED_DATE,
+            'unit_amount': 1.0,
+        })
+        self.assertTrue(line)
+
+    # ── Group 3 — write(): current-state check ────────────────────────────────
+
+    def test_write_locked_record_raises(self):
+        """Editing any field of a locked timesheet raises UserError."""
+        line = self._make_line(LOCKED_DATE)
+        with self.assertRaises(UserError):
+            line.with_user(self.regular_user).sudo().write({'unit_amount': 2.0})
+
+    def test_write_open_record_ok(self):
+        """Editing a timesheet in an open period always succeeds."""
+        line = self._make_line(OPEN_DATE)
+        line.with_user(self.regular_user).sudo().write({'unit_amount': 2.0})
+        self.assertEqual(line.unit_amount, 2.0)
+
+    # ── Group 4 — write(): destination-state check ────────────────────────────
+
+    def test_write_date_to_locked_raises(self):
+        """Moving an open timesheet to a locked date raises UserError."""
+        line = self._make_line(OPEN_DATE)
+        with self.assertRaises(UserError):
+            line.with_user(self.regular_user).sudo().write({'date': LOCKED_DATE})
+
+    def test_write_employee_narrows_bypass_raises(self):
+        """Switching to an employee without bypass raises UserError when date is locked."""
+        # Line in locked period — OK because employee_bypass covers it
+        line = self._make_line(LOCKED_DATE, employee=self.employee_bypass)
+        # Switching to regular employee removes the bypass → destination state blocked
+        with self.assertRaises(UserError):
+            line.with_user(self.regular_user).sudo().write(
+                {'employee_id': self.employee.id}
+            )
+
+    def test_write_date_to_open_ok(self):
+        """Moving a timesheet to another open date always succeeds."""
+        line = self._make_line(OPEN_DATE)
+        new_date = OPEN_DATE + timedelta(days=1)
+        line.with_user(self.regular_user).sudo().write({'date': new_date})
+        self.assertEqual(line.date, new_date)
+
+    def test_write_cumulative_date_to_locked_ok(self):
+        """Cumulative lines skip the destination-state check."""
+        line = self._make_line(OPEN_DATE, is_cumulative=True)
+        line.write({'date': LOCKED_DATE})
+        self.assertEqual(line.date, LOCKED_DATE)
+
+    # ── Group 5 — unlink() ────────────────────────────────────────────────────
+
+    def test_unlink_locked_raises(self):
+        """Deleting a timesheet in a locked period raises UserError."""
+        line = self._make_line(LOCKED_DATE)
+        with self.assertRaises(UserError):
+            line.with_user(self.regular_user).sudo().unlink()
+
+    def test_unlink_open_ok(self):
+        """Deleting a timesheet in an open period succeeds."""
+        line = self._make_line(OPEN_DATE)
+        line.with_user(self.regular_user).sudo().unlink()
+
+    def test_unlink_cumulative_locked_ok(self):
+        """Deleting a cumulative line skips the lock check."""
+        line = self._make_line(LOCKED_DATE, is_cumulative=True)
+        line.unlink()
+
+    # ── Group 6 — som.worked.week.write() ─────────────────────────────────────
+
+    def test_worked_week_write_locked_raises(self):
+        """Editing a worked week that falls in a locked period raises UserError."""
+        with self.assertRaises(UserError):
+            self.worked_week_locked.with_user(self.regular_user).sudo().write(
+                {'som_employee_id': self.employee.id}
+            )
+
+    def test_worked_week_write_open_ok(self):
+        """Editing a worked week in an open period succeeds."""
+        self.worked_week_open.with_user(self.regular_user).sudo().write(
+            {'som_employee_id': self.employee.id}
+        )
+
+    # ── Group 7 — cron ────────────────────────────────────────────────────────
+
+    def test_cron_sets_lock_date(self):
+        """Cron sets the lock date to the last day of the previous month."""
+        today = date.today()
+        expected_lock = today.replace(day=1) - timedelta(days=1)
+        self.env['res.company']._do_update_timesheet_lock_date()
+        self.assertEqual(self.env.company.som_timesheet_lock_date, expected_lock)

--- a/somenergia_custom/tests/test_timesheet_visible_projects.py
+++ b/somenergia_custom/tests/test_timesheet_visible_projects.py
@@ -1,0 +1,118 @@
+# -*- coding: utf-8 -*-
+from odoo.tests.common import TransactionCase, tagged
+from odoo.exceptions import AccessError
+
+
+@tagged('timesheet_visible_projects')
+class TestTimesheetVisibleProjects(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.group_timesheet_user = cls.env.ref('hr_timesheet.group_hr_timesheet_user')
+        cls.group_visible_projects = cls.env.ref(
+            'somenergia_custom.som_group_hr_timesheet_visible_projects'
+        )
+
+        cls.user_regular = cls._create_user('regular', [cls.group_timesheet_user.id])
+        cls.user_visible = cls._create_user('visible', [cls.group_visible_projects.id])
+        cls.user_other = cls._create_user('other', [cls.group_timesheet_user.id])
+
+        cls.project_public = cls.env['project.project'].create({
+            'name': 'Public Timesheet Project',
+            'privacy_visibility': 'employees',
+            'allow_timesheets': True,
+        })
+        cls.project_private = cls.env['project.project'].create({
+            'name': 'Private Timesheet Project',
+            'privacy_visibility': 'followers',
+            'allow_timesheets': True,
+        })
+
+        cls.task_public = cls.env['project.task'].create({
+            'name': 'Public Task',
+            'project_id': cls.project_public.id,
+        })
+        cls.task_private = cls.env['project.task'].create({
+            'name': 'Private Task',
+            'project_id': cls.project_private.id,
+        })
+
+        cls.line_visible_public = cls._create_timesheet(
+            cls.user_visible, cls.task_public, 2.0, 'Visible public work'
+        )
+        cls.line_other_public = cls._create_timesheet(
+            cls.user_other, cls.task_public, 3.0, 'Other public work'
+        )
+        cls.line_other_private = cls._create_timesheet(
+            cls.user_other, cls.task_private, 4.0, 'Other private work'
+        )
+
+    @classmethod
+    def _create_user(cls, login, group_ids):
+        employee = cls.env['hr.employee'].create({
+            'name': login.title(),
+        })
+        user = cls.env['res.users'].create({
+            'name': login.title(),
+            'login': '%s@example.com' % login,
+            'email': '%s@example.com' % login,
+            'employee_id': employee.id,
+            'groups_id': [(6, 0, [cls.env.ref('base.group_user').id] + group_ids)],
+        })
+        employee.user_id = user.id
+        return user
+
+    @classmethod
+    def _create_timesheet(cls, user, task, unit_amount, name):
+        return cls.env['account.analytic.line'].create({
+            'name': name,
+            'user_id': user.id,
+            'employee_id': user.employee_id.id,
+            'project_id': task.project_id.id,
+            'task_id': task.id,
+            'unit_amount': unit_amount,
+        })
+
+    def test_visible_projects_group_can_read_other_public_timesheets(self):
+        lines = self.env['account.analytic.line'].with_user(self.user_visible).search([
+            ('id', 'in', [
+                self.line_visible_public.id,
+                self.line_other_public.id,
+                self.line_other_private.id,
+            ]),
+        ])
+
+        self.assertEqual(
+            set(lines.ids),
+            {self.line_visible_public.id, self.line_other_public.id},
+        )
+
+    def test_regular_timesheet_user_still_sees_only_own_lines(self):
+        lines = self.env['account.analytic.line'].with_user(self.user_regular).search([
+            ('id', 'in', [
+                self.line_visible_public.id,
+                self.line_other_public.id,
+                self.line_other_private.id,
+            ]),
+        ])
+
+        self.assertEqual(lines.ids, [])
+
+    def test_visible_projects_group_cannot_write_other_timesheets(self):
+        with self.assertRaises(AccessError):
+            self.line_other_public.with_user(self.user_visible).write({'name': 'Blocked'})
+
+    def test_visible_projects_group_keeps_own_write_access(self):
+        self.line_visible_public.with_user(self.user_visible).write({'name': 'Updated own line'})
+        self.assertEqual(self.line_visible_public.name, 'Updated own line')
+
+    def test_visible_projects_group_broadens_analysis_report(self):
+        report_lines = self.env['timesheets.analysis.report'].with_user(self.user_visible).search([
+            ('project_id', 'in', [self.project_public.id, self.project_private.id]),
+        ])
+
+        self.assertEqual(
+            set(report_lines.mapped('id')),
+            {self.line_visible_public.id, self.line_other_public.id},
+        )

--- a/somenergia_custom/tests/test_timesheet_visible_projects.py
+++ b/somenergia_custom/tests/test_timesheet_visible_projects.py
@@ -32,10 +32,12 @@ class TestTimesheetVisibleProjects(TransactionCase):
         cls.task_public = cls.env['project.task'].create({
             'name': 'Public Task',
             'project_id': cls.project_public.id,
+            'som_project_id': cls.project_public.id,
         })
         cls.task_private = cls.env['project.task'].create({
             'name': 'Private Task',
             'project_id': cls.project_private.id,
+            'som_project_id': cls.project_private.id,
         })
 
         cls.line_visible_public = cls._create_timesheet(

--- a/somenergia_custom/views/hr_employee_view.xml
+++ b/somenergia_custom/views/hr_employee_view.xml
@@ -92,6 +92,14 @@
                     attrs="{'invisible': [('som_disable_att_restrictions', '=', False)], 'required': [('som_disable_att_restrictions', '=', True)]}"/>
                 <field name="som_disable_att_restrictions_date_to"
                     attrs="{'invisible': [('som_disable_att_restrictions', '=', False)], 'required': [('som_disable_att_restrictions', '=', True)]}"/>
+                <field name="som_lock_bypass_date_from"
+                       string="Bypass tancament des de"
+                       groups="hr_timesheet.group_timesheet_manager"
+                       help="Permet editar períodes tancats a partir d'aquesta data (inclusive)."/>
+                <field name="som_lock_bypass_date_to"
+                       string="Bypass tancament fins a"
+                       groups="hr_timesheet.group_timesheet_manager"
+                       help="Permet editar períodes tancats fins a aquesta data (inclusive)."/>
             </xpath>
         </field>
     </record>

--- a/somenergia_custom/views/hr_timesheet_view.xml
+++ b/somenergia_custom/views/hr_timesheet_view.xml
@@ -2,6 +2,25 @@
 <odoo>
     <data>
 
+        <record id="hr_timesheet.act_hr_timesheet_line" model="ir.actions.act_window">
+            <field name="domain">[
+                ('project_id', '!=', False),
+                ('user_id', '=', uid),
+                '|',
+                    ('project_id.user_id', '=', False),
+                    ('project_id.user_id', '!=', 1)
+            ]</field>
+        </record>
+
+        <record id="hr_timesheet.timesheet_action_all" model="ir.actions.act_window">
+            <field name="domain">[
+                ('project_id', '!=', False),
+                '|',
+                    ('project_id.user_id', '=', False),
+                    ('project_id.user_id', '!=', 1)
+            ]</field>
+        </record>
+
         <menuitem id="som_timesheet_menu_visible_projects"
                   name="Visible Timesheets"
                   parent="hr_timesheet.timesheet_menu_root"

--- a/somenergia_custom/views/hr_timesheet_view.xml
+++ b/somenergia_custom/views/hr_timesheet_view.xml
@@ -2,6 +2,13 @@
 <odoo>
     <data>
 
+        <menuitem id="som_timesheet_menu_visible_projects"
+                  name="Visible Timesheets"
+                  parent="hr_timesheet.timesheet_menu_root"
+                  action="hr_timesheet.timesheet_action_all"
+                  sequence="35"
+                  groups="somenergia_custom.som_group_hr_timesheet_visible_projects"/>
+
         <record id="som_timesheet_view_tree_user" model="ir.ui.view">
             <field name="name">som.account.analytic.line.view.tree.with.user</field>
             <field name="model">account.analytic.line</field>

--- a/somenergia_custom/views/project_task_view.xml
+++ b/somenergia_custom/views/project_task_view.xml
@@ -68,8 +68,8 @@
                 </xpath>
                 <xpath expr="//kanban/field[@name='allow_milestones']" position="after">
                     <field name="som_department_ids"/>
-                    <field name="som_project_id" invisible="1"/>
-                    <field name="som_additional_project_id"/>
+                    <field name="som_project_id"/>
+                    <field name="som_additional_project_id" invisible="1"/>
                 </xpath>
                 <xpath expr="//strong[hasclass('o_kanban_record_title')]" position="replace">
                     <strong class="o_kanban_record_title">
@@ -97,8 +97,8 @@
             <field name="arch" type="xml">
                 <field name="user_ids" position="after">
                     <field name="som_department_ids" widget="many2many_tags" optional="show"/>
-                    <field name="som_project_id" invisible="1"/>
-                    <field name="som_additional_project_id" optional="show"/>
+                    <field name="som_project_id" optional="show"/>
+                    <field name="som_additional_project_id" invisible="1"/>
                 </field>
             </field>
         </record>

--- a/somenergia_custom/views/project_task_view.xml
+++ b/somenergia_custom/views/project_task_view.xml
@@ -11,6 +11,8 @@
                            invisible="1"/>
                     <field name="som_additional_project_domain_ids"
                            invisible="1"/>
+                    <field name="allow_timesheets"
+                           invisible="1"/>
                     <field name="kanban_state"
                            invisible="1"/>
                     <field name="som_hide_partner"
@@ -30,18 +32,18 @@
                 </xpath>
                 <xpath expr="//field[@name='user_ids']" position="after">
                     <field name="som_department_ids" widget="many2many_tags"/>
+                    <field name="som_project_id"
+                           options="{'no_open': True}"
+                           string="Tasca Servei"
+                           domain="[('id', 'in', som_project_area_domain_ids)]"
+                           attrs="{'required': [('allow_timesheets', '=', True)]}"
+                           invisible="0"
+                           readonly="0"/>
                     <field name="som_additional_project_id"
                            options="{'no_open': True}"
                            string="Transversal Project"
-                           domain="[('id', 'in', som_additional_project_domain_ids)]"
-                           readonly="0"/>
-                </xpath>
-                <xpath expr="//field[@name='tag_ids']" position="after">
-                    <field name="som_project_id"
-                           options="{'no_open': True}"
-                           string="Area"
-                           domain="[('id', 'in', som_project_area_domain_ids)]"
                            invisible="1"
+                           domain="[('id', 'in', som_additional_project_domain_ids)]"
                            readonly="0"/>
                 </xpath>
                 <xpath expr="//widget[@name='web_ribbon']" position="after">

--- a/somenergia_custom/views/res_config_settings_views.xml
+++ b/somenergia_custom/views/res_config_settings_views.xml
@@ -37,8 +37,7 @@
                 <field name="som_restrictive_overtime" class="text-center"/><span>Enable restrictive overtime</span>
             </xpath>
 
-            <xpath expr="//div[@data-key='hr_attendance']" position="inside">
-                <h2>Attendance Settings</h2>
+            <xpath expr="//div[@data-key='hr_attendance']" position="inside">                <h2>Attendance Settings</h2>
                 <div
                     class="row mt16 o_settings_container"
                     name="som_attendance_settings_container"
@@ -103,6 +102,48 @@
             </xpath>
 
 
+        </field>
+    </record>
+
+    <record id="res_config_settings_view_form_timesheet_lock" model="ir.ui.view">
+        <field name="model">res.config.settings</field>
+        <field name="priority" eval="99"/>
+        <field name="inherit_id" ref="hr_timesheet.res_config_settings_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[@data-key='hr_timesheet']" position="inside">
+                <h2>Tancament de períodes</h2>
+                <div class="row mt16 o_settings_container" name="som_timesheet_lock_container">
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane"/>
+                        <div class="o_setting_right_pane">
+                            <label for="som_timesheet_lock_date" string="Data de tancament"/>
+                            <div class="text-muted">
+                                Les setmanes de treball que finalitzen en o abans d'aquesta data queden bloquejades.
+                                Els administradors de Fulls d'hores sempre poden editar.
+                            </div>
+                            <div class="content-group mt8">
+                                <field name="som_timesheet_lock_date"/>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane"/>
+                        <div class="o_setting_right_pane">
+                            <label string="Bypass global (rang de dates)" for="som_timesheet_lock_bypass_date_from"/>
+                            <div class="text-muted">
+                                Permet editar els períodes tancats que caiguen dins aquest rang, per a tots els usuaris.
+                                El bypass és actiu només si ambdues dates estan definides.
+                            </div>
+                            <div class="content-group mt8">
+                                <label string="Des de" for="som_timesheet_lock_bypass_date_from" class="o_light_label"/>
+                                <field name="som_timesheet_lock_bypass_date_from"/>
+                                <label string="Fins a" for="som_timesheet_lock_bypass_date_to" class="o_light_label ms-2"/>
+                                <field name="som_timesheet_lock_bypass_date_to"/>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </xpath>
         </field>
     </record>
 

--- a/somenergia_custom/views/res_config_settings_views.xml
+++ b/somenergia_custom/views/res_config_settings_views.xml
@@ -142,6 +142,18 @@
                             </div>
                         </div>
                     </div>
+                    <div class="col-12 col-lg-6 o_setting_box">
+                        <div class="o_setting_left_pane"/>
+                        <div class="o_setting_right_pane">
+                            <label for="som_worked_week_help_url" string="URL d'ajuda de worked week"/>
+                            <div class="text-muted">
+                                Enllaç que s'obrirà des del botó d'ajuda del formulari de worked week.
+                            </div>
+                            <div class="content-group mt8">
+                                <field name="som_worked_week_help_url" placeholder="https://..."/>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </xpath>
         </field>

--- a/somenergia_custom/views/som_worked_week_view.xml
+++ b/somenergia_custom/views/som_worked_week_view.xml
@@ -71,12 +71,12 @@
                                 string="Ajuda"
                                 icon="fa-question-circle"
                                 class="btn btn-secondary"/>
-                        <span class="badge rounded-pill text-bg-warning ms-2"
-                              attrs="{'invisible': [('som_is_locked', '=', False)]}">
-                            Període tancat
-                        </span>
                     </header>
                     <sheet>
+                        <widget name="web_ribbon"
+                                title="Període tancat"
+                                bg_color="bg-warning"
+                                attrs="{'invisible': [('som_is_locked', '=', False)]}"/>
                         <group>
                             <group>
                                 <field name="som_week_id"

--- a/somenergia_custom/views/som_worked_week_view.xml
+++ b/somenergia_custom/views/som_worked_week_view.xml
@@ -68,7 +68,7 @@
                         <field name="som_is_locked" invisible="1"/>
                         <span class="badge rounded-pill text-bg-warning ms-2"
                               attrs="{'invisible': [('som_is_locked', '=', False)]}">
-                            Periode tancat
+                            Període tancat
                         </span>
                     </header>
                     <sheet>

--- a/somenergia_custom/views/som_worked_week_view.xml
+++ b/somenergia_custom/views/som_worked_week_view.xml
@@ -10,7 +10,8 @@
                 <tree string="Worked weeks"
                       decoration-success="som_total_unassigned_hours == 0 and som_total_worked_hours != 0"
                       decoration-danger="som_total_assigned_hours == 0 and som_total_worked_hours != 0"
-                      decoration-warning="(som_total_assigned_hours != 0 and som_total_unassigned_hours != 0 and som_total_worked_hours != 0) or (som_total_unassigned_hours &lt; 0)">
+                      decoration-warning="(som_total_assigned_hours != 0 and som_total_unassigned_hours != 0 and som_total_worked_hours != 0) or (som_total_unassigned_hours &lt; 0)"
+                      decoration-muted="som_is_locked == True">
                     <field name="som_week_id"/>
                     <field name="som_employee_id" optional="hide" />
                     <field name="som_timesheet_ids" optional="hide"/>
@@ -20,6 +21,7 @@
                            widget="float_time"/>
                     <field name="som_total_unassigned_hours"
                            widget="float_time"/>
+                    <field name="som_is_locked" optional="show" string="Tancat" readonly="1"/>
                     <field name="som_cw_date_rel" optional="hide" />
                     <field name="som_cw_date_end_rel" optional="hide" />
                     <field name="som_cw_week_number_rel" optional="hide" />
@@ -63,6 +65,11 @@
             <field name="arch" type="xml">
                 <form string="Worked Week">
                     <header>
+                        <field name="som_is_locked" invisible="1"/>
+                        <span class="badge rounded-pill text-bg-warning ms-2"
+                              attrs="{'invisible': [('som_is_locked', '=', False)]}">
+                            Periode tancat
+                        </span>
                     </header>
                     <sheet>
                         <group>
@@ -100,7 +107,7 @@
                                        options="{'no_open': True}"
                                        attrs="{'readonly': [('som_is_cumulative', '=', True)]}"
                                        required="True"
-                                       string="Scope"
+                                       string="Tasca Servei"
                                        domain="[('id', 'in', som_project_area_domain_ids)]"
                                        readonly="0"/>
                                 <field name="som_additional_project_id"
@@ -109,6 +116,7 @@
                                        required="False"
                                        string="Projecte"
                                        domain="[('id', 'in', som_additional_project_domain_ids)]"
+                                       invisible="1"
                                        readonly="0"/>
                                 <field name='task_id' readonly="1" optional="show"/>
                                 <field name="name"

--- a/somenergia_custom/views/som_worked_week_view.xml
+++ b/somenergia_custom/views/som_worked_week_view.xml
@@ -121,8 +121,9 @@
                                        required="False"
                                        string="Projecte"
                                        domain="[('id', 'in', som_additional_project_domain_ids)]"
-                                       invisible="1"
-                                       readonly="0"/>
+                                       invisible="0"
+                                       readonly="0"
+                                       optional="hide"/>
                                 <field name='task_id' readonly="1" optional="show"/>
                                 <field name="name"
                                        attrs="{'readonly': [('som_is_cumulative', '=', True)]}"/>

--- a/somenergia_custom/views/som_worked_week_view.xml
+++ b/somenergia_custom/views/som_worked_week_view.xml
@@ -66,6 +66,11 @@
                 <form string="Worked Week">
                     <header>
                         <field name="som_is_locked" invisible="1"/>
+                        <button name="action_open_help_url"
+                                type="object"
+                                string="Ajuda"
+                                icon="fa-question-circle"
+                                class="btn btn-secondary"/>
                         <span class="badge rounded-pill text-bg-warning ms-2"
                               attrs="{'invisible': [('som_is_locked', '=', False)]}">
                             Periode tancat


### PR DESCRIPTION
## Description
https://somenergia.openproject.com/wp/1681


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds company-level timesheet period locking with global and per-employee bypasses, task service‑project enforcement, date-aware project pickers, a read-only visibility group, UI help and a “Període tancat” ribbon, plus an optional monthly cron. Also unblocks linked-line removals so a locked period can’t block deleting or unlinking a transversal copy.

- **New Features**
  - Locking: company lock date; global/per-employee bypass ranges; managers exempt. Enforced on `account.analytic.line` create/write/unlink and `som.worked.week` write. Validates destination date/employee; cumulative lines excluded. Linked transversal lines are removed with a skip‑lock context on write/unlink. Optional cron “Som - Update timesheet lock date” (inactive) sets last day of previous month (runs monthly on day 10 at 06:00 if enabled).
  - Tasks & projects: timesheets from tasks use `som_project_id` (required when `allow_timesheets`); changing it is blocked if any timesheet uses the current service project. Project pickers filter area/transversal projects by validity (week dates for timesheets/worked weeks; today for tasks). Legacy transversal project is hidden on tasks and optional on worked weeks.
  - UI & access: worked‑week list mutes locked rows and shows “Tancat”; form shows a “Període tancat” ribbon and an “Ajuda” button (opens configured URL). Timesheet menus hide OdooBot‑managed project entries. New group `som_group_hr_timesheet_visible_projects` gives read‑only access to others’ timesheets and the analysis report on visible/followed/assigned projects, plus a “Visible Timesheets” menu. Normalized Many2many rule domains.

- **Migration**
  - Post‑migrate 16.0.1.1.0: closes legacy area/transversal projects and creates/aligned 2026 area projects; if the rollout owner isn’t found, projects are created without `user_id`.
  - Configure in Settings > Timesheets: lock date, optional global bypass, and the worked‑week help URL; optionally activate the monthly cron. Set per‑employee bypass dates on `hr.employee`. Assign users to `som_group_hr_timesheet_visible_projects`. Set `som_project_id` on tasks that allow timesheets.

<sup>Written for commit cf8e718d57323369124a9897828e598c26fd059d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/91?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR introduces company-level timesheet period locking with global and per-employee bypass windows, date-aware project pickers on timesheets and worked weeks, a read-only \"visible projects\" group, and a post-migration that closes legacy area/transversal projects and creates/aligns 2026 area projects.

- **Lock enforcement**: `res.company._is_period_locked()` is the single lock-check primitive, used in `account.analytic.line` create/write/unlink and `som.worked.week` write. Linked transversal timesheets are exempted from the lock via a `skip_linked_timesheet_lock` context introduced to fix the unlink path — but the parallel path that mutates `project_id` on the linked record (write with a new `som_additional_project_id`) does not carry that context and can be blocked if the linked timesheet's date has drifted into a locked period.
- **Access control**: A new `som_group_hr_timesheet_visible_projects` group adds read-only record rules on `account.analytic.line` and the analysis report, scoped to projects that are public, followed, or have the user assigned; the new \"Visible Timesheets\" menu exposes this. Migration and cron are both safe for the described single-company setup.
</details>


<details><summary><h3>Confidence Score: 4/5</h3></summary>

Safe to merge with one remaining fix: changing a transversal project on a main timesheet in an open period can still be blocked by a lock on the linked timesheet's stale date.

The lock guard is correctly applied to create, write, and unlink on analytic lines, and the unlink path for linked transversal timesheets uses the skip-context fix. However, the write path that directly assigns project_id on the linked timesheet does not use that context, so a user whose main record has been moved to a new open date can be stuck unable to change the transversal project because the linked line still carries the older locked date. All other changes — the bypass logic, the worked-week guard, the new access group, the migration, and the cron — are correct.

somenergia_custom/models/analytic_account.py — specifically the block around line 249 where record.som_timesheet_add_id.project_id is set directly without the skip-lock context.
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| somenergia_custom/models/analytic_account.py | Adds period-lock checks to create/write/unlink; fixes linked-timesheet unlink via skip-context, but the parallel path that updates the linked timesheet's project_id does not use the skip-context and can be blocked by the locked date of the linked record. |
| somenergia_custom/models/res_company.py | Adds timesheet lock date, global/employee bypass fields, _is_period_locked helper, and optional monthly cron; logic is correct and safe for single-company setup. |
| somenergia_custom/models/som_worked_week.py | Adds date-aware project domain compute, som_is_locked field, write() lock guard, and help-URL action; logic is straightforward and consistent with the rest of the lock implementation. |
| somenergia_custom/migrations/16.0.1.1.0/post-migrate.py | Closes legacy area/transversal projects and creates/aligns 2026 area projects; hardcoded NEW_PROJECT_MANAGER_ID=281 is gracefully handled with a fallback warning, migration is safe. |
| somenergia_custom/security/hr_timesheet_security.xml | Adds new group som_group_hr_timesheet_visible_projects with read-only rules for visible/followed/assigned-project timesheets; rule domains look correct. |
| somenergia_custom/tests/test_timesheet_period_lock.py | Comprehensive 7-group test suite covering lock boundary, manager bypass, employee bypass, create/write/unlink guards, and cron; good coverage of the new locking logic. |

</details>


<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant AnalyticLine as account.analytic.line
    participant Company as res.company
    participant LinkedLine as Linked Transversal Line

    User->>AnalyticLine: "write({som_additional_project_id: new_project})"
    AnalyticLine->>AnalyticLine: _check_period_lock() [main record – open date ✓]
    AnalyticLine->>LinkedLine: "project_id = new_project (field assignment → write)"
    LinkedLine->>LinkedLine: _check_period_lock()
    Note over LinkedLine: linked date may be locked (dates never synced after move)
    alt linked date is locked
        LinkedLine-->>User: UserError – locked period
    else linked date is open
        LinkedLine-->>AnalyticLine: OK
        AnalyticLine->>Company: _is_period_locked(new_date, employee)
        Company-->>AnalyticLine: result
        AnalyticLine-->>User: write succeeds
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant AnalyticLine as account.analytic.line
    participant Company as res.company
    participant LinkedLine as Linked Transversal Line

    User->>AnalyticLine: "write({som_additional_project_id: new_project})"
    AnalyticLine->>AnalyticLine: _check_period_lock() [main record – open date ✓]
    AnalyticLine->>LinkedLine: "project_id = new_project (field assignment → write)"
    LinkedLine->>LinkedLine: _check_period_lock()
    Note over LinkedLine: linked date may be locked (dates never synced after move)
    alt linked date is locked
        LinkedLine-->>User: UserError – locked period
    else linked date is open
        LinkedLine-->>AnalyticLine: OK
        AnalyticLine->>Company: _is_period_locked(new_date, employee)
        Company-->>AnalyticLine: result
        AnalyticLine-->>User: write succeeds
    end
```

</a>
</details>


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `somenergia_custom/models/analytic_account.py`, line 258-266 ([link](https://github.com/som-energia/somenergia-odoo/blob/50c4212cf32f13b690eaddc807530916254d29db/somenergia_custom/models/analytic_account.py#L258-L266)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Linked-timesheet unlink blocked when dates have diverged**

   When a user writes `som_additional_project_id=False` on a main timesheet that is in an **open** period, the code calls `record.som_timesheet_add_id.unlink()` (line ~266). That `unlink()` now calls `_check_period_lock()` on the *linked* timesheet. The linked timesheet's `date` is a copy from when it was created and is **never updated** when the main timesheet's `date` changes (only `unit_amount` is synced). So if the main timesheet was moved to a later open date while the original date is now locked, `unlink()` will raise `UserError` and the user is stuck — they cannot remove the transversal project even though the record they are editing is not locked.

   To fix, call `unlink()` as superuser (`record.som_timesheet_add_id.sudo().unlink()`) or skip the lock check for internally-triggered deletions by passing a context flag (e.g. `with_context(skip_period_lock=True)`).
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["🐛 unblock unlink when linked transversa..."](https://github.com/som-energia/somenergia-odoo/commit/3d36ad7644f0071c4529db78d79904ded9a8d433) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36543430)</sub>

<!-- /greptile_comment -->