### PR TITLE
🐛 fix remove archived default followers from new tasks

### DIFF
--- a/somenergia_custom/models/project_task.py
+++ b/somenergia_custom/models/project_task.py
@@ -44,13 +44,20 @@ class Task(models.Model):
             self.env["ir.config_parameter"].sudo().get_param("som_avoid_default_task_followers")
         )
         if flag_avoid_default_followers:
-            for task_id in task_ids:
-                partner_to_remove_ids = (task_id.message_partner_ids.user_ids - task_id.user_ids).partner_id
-                if partner_to_remove_ids:
-                    task_id.sudo().message_follower_ids.filtered(
-                        lambda x: x.partner_id.id in partner_to_remove_ids.ids
-                    ).unlink()
+            task_ids._remove_default_followers()
         return task_ids
+
+    def _remove_default_followers(self):
+        for task in self:
+            follower_user_ids = task.message_partner_ids.with_context(
+                active_test=False
+            ).user_ids
+            assigned_user_ids = task.with_context(active_test=False).user_ids
+            partner_to_remove_ids = (follower_user_ids - assigned_user_ids).partner_id
+            if partner_to_remove_ids:
+                task.sudo().message_follower_ids.filtered(
+                    lambda follower: follower.partner_id in partner_to_remove_ids
+                ).unlink()
 
     def button_start_work(self):
         internal_project_ids = self.env['project.project'].get_internal_projects()

--- a/somenergia_custom/models/project_task.py
+++ b/somenergia_custom/models/project_task.py
@@ -53,7 +53,9 @@ class Task(models.Model):
                 active_test=False
             ).user_ids
             assigned_user_ids = task.with_context(active_test=False).user_ids
-            partner_to_remove_ids = (follower_user_ids - assigned_user_ids).partner_id
+            partner_to_remove_ids = (
+                follower_user_ids.partner_id - assigned_user_ids.partner_id
+            )
             if partner_to_remove_ids:
                 task.sudo().message_follower_ids.filtered(
                     lambda follower: follower.partner_id in partner_to_remove_ids

--- a/somenergia_custom/tests/test_project_task.py
+++ b/somenergia_custom/tests/test_project_task.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from freezegun import freeze_time
 
 from odoo import fields
+from odoo.tests import new_test_user
 from odoo.tests.common import TransactionCase, tagged
 
 
@@ -51,3 +52,31 @@ class TestProjectTask(TransactionCase):
         self.assertNotIn(future_project, task.som_project_area_domain_ids)
         self.assertIn(timeless_project, task.som_project_area_domain_ids)
         self.assertNotIn(non_area_project, task.som_project_area_domain_ids)
+
+    def test_create_removes_archived_project_followers(self):
+        self.env['ir.config_parameter'].set_param(
+            'som_avoid_default_task_followers', True
+        )
+        archived_follower = new_test_user(
+            self.env, login='archived_project_follower', groups='base.group_user'
+        )
+        assigned_follower = new_test_user(
+            self.env, login='assigned_project_follower', groups='base.group_user'
+        )
+        project = self.env['project.project'].create({
+            'name': 'Project With Followers',
+        })
+        project.message_subscribe([
+            archived_follower.partner_id.id,
+            assigned_follower.partner_id.id,
+        ])
+        archived_follower.active = False
+
+        task = self.env['project.task'].create({
+            'name': 'Task Without Default Followers',
+            'project_id': project.id,
+            'user_ids': [(6, 0, [assigned_follower.id])],
+        })
+
+        self.assertNotIn(archived_follower.partner_id, task.message_partner_ids)
+        self.assertIn(assigned_follower.partner_id, task.message_partner_ids)


### PR DESCRIPTION
## Description
fix remove archived default followers from new tasks


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops archived and unassigned project followers from being auto-added to new tasks when `som_avoid_default_task_followers` is on. Keeps only assignees as followers.

- **Bug Fixes**
  - Use a partner-level diff with `active_test=False` to remove archived/unassigned followers while keeping assigned partners.

- **Refactors**
  - Extracted cleanup logic to `project.task._remove_default_followers()` for reuse and clarity.

<sup>Written for commit 68acd4efd6daf975abe4ae464f53ec93f29e98d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR prevents archived default followers from being added to new tasks. The main changes are:

- Extract follower cleanup into `_remove_default_followers()`.
- Keep partners linked to assigned users as task followers.
- Add coverage for archived and assigned project followers.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- The updated partner comparison preserves followers linked to assigned users.
- The added test covers archived follower removal and assigned follower retention.
- No blocking issues were found in the changed code.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| somenergia_custom/models/project_task.py | Moves follower cleanup into a helper and removes only follower partners that do not belong to assigned users. |
| somenergia_custom/tests/test_project_task.py | Adds task-creation coverage for removing archived project followers while preserving assigned followers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Update somenergia\_custom/models/project\_..."](https://github.com/som-energia/somenergia-odoo/commit/68acd4efd6daf975abe4ae464f53ec93f29e98d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44112715)</sub>

<!-- /greptile_comment -->