### PR TITLE
📌 Fix dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@
 pydantic
 typing
 gspread
-pyOpenSSL==25.3.0
+pyOpenSSL==26.2.0


### PR DESCRIPTION
## Description
Fix dependency



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `pyOpenSSL` from 25.3.0 to 26.2.0 to resolve dependency conflicts and improve compatibility.

<sup>Written for commit 1741e5209a93e4c59dddf0079e678b2ce8cd95f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/94?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

This PR updates one dependency pin.

- Changes `pyOpenSSL` from version 25.3.0 to 26.2.0 in `requirements.txt`.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

This looks safe to merge.

- No blocking issues found in the changed code.
- No repository code directly imports pyOpenSSL.
- No declared runtime or dependency constraint conflicts with the new pin.

</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| requirements.txt | Updates the pinned pyOpenSSL version; no repository-supported incompatibility was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["📌 Fix dependency"](https://github.com/som-energia/somenergia-odoo/commit/1741e5209a93e4c59dddf0079e678b2ce8cd95f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44162397)</sub>

<!-- /greptile_comment -->