### PR TITLE
👔 filter ERP lead matches by state=done before marking as won

### DIFF
--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -396,7 +396,7 @@ class Lead(models.Model):
             value_to_search = getattr(self, lead_field, None)
             if not value_to_search:
                 continue
-            domain = [('crm_lead_id', '=', 0)]
+            domain = [('crm_lead_id', '=', 0), ('state', '=', 'done')]
             erp_lead_id = search_strategies[lead_field](erp_lead_obj, domain, value_to_search)
             if erp_lead_id:
                 return erp_lead_id[0]

--- a/som_crm/models/crm_lead.py
+++ b/som_crm/models/crm_lead.py
@@ -660,7 +660,7 @@ class Lead(models.Model):
         print("Connection OK\n")
 
         erp_lead_obj = c.model('giscedata.crm.lead')
-        base_domain = [('crm_lead_id', '=', 0)]
+        base_domain = [('crm_lead_id', '=', 0), ('state', '=', 'done')]
 
         strategies = [
             ('som_cups',   'CUPS',  self._erp_search_by_cups),

--- a/som_crm/tests/test_crm_lead_sync.py
+++ b/som_crm/tests/test_crm_lead_sync.py
@@ -152,7 +152,44 @@ class TestErpLeadSync(TransactionCase):
             [('titular_phone', '=', '933001122')], limit=1
         )
 
-    def test_get_contract_in_erp_priority(self):
+    def test_get_contract_in_erp_filters_by_state_done(self):
+        """
+        Test that get_contract_in_erp only matches ERP leads with state='done'.
+        Leads in other states (e.g. 'open') must not be matched.
+        """
+        _logger.info("--> Test: test_get_contract_in_erp_filters_by_state_done")
+
+        mock_erp_lead_obj = MagicMock()
+        # ERP returns nothing — simulates that the lead exists but state != 'done'
+        mock_erp_lead_obj.search.return_value = []
+
+        erp_id = self.lead_to_find_by_cups.get_contract_in_erp(mock_erp_lead_obj)
+
+        self.assertFalse(erp_id)
+        # Verify that state='done' is always included in the search domain
+        for call in mock_erp_lead_obj.search.call_args_list:
+            domain = call[0][0]
+            self.assertIn(('state', '=', 'done'), domain)
+
+    def test_get_contract_in_erp_matches_only_done_state(self):
+        """
+        Test that get_contract_in_erp marks a lead as won only when
+        the ERP lead has state='done'.
+        """
+        _logger.info("--> Test: test_get_contract_in_erp_matches_only_done_state")
+
+        mock_erp_lead_obj = MagicMock()
+        mock_erp_lead_obj.search.return_value = [201]
+
+        erp_id = self.lead_to_find_by_cups.get_contract_in_erp(mock_erp_lead_obj)
+
+        self.assertEqual(erp_id, 201)
+        # The domain used must include the state filter
+        call_domain = mock_erp_lead_obj.search.call_args_list[0][0][0]
+        self.assertIn(('crm_lead_id', '=', 0), call_domain)
+        self.assertIn(('state', '=', 'done'), call_domain)
+
+
         """
         Test the logic and search priority in 'get_contract_in_erp'.
         It should find by CUPS first, even if it has other data.
@@ -177,7 +214,7 @@ class TestErpLeadSync(TransactionCase):
         self.assertEqual(erp_id, 101)
         # We verify that search was called with the CUPS domain
         mock_erp_lead_obj.search.assert_called_once_with(
-            [('crm_lead_id', '=', 0), ('cups', '=ilike', 'ES_PRIORITY_TEST%')], limit=1
+            [('crm_lead_id', '=', 0), ('state', '=', 'done'), ('cups', '=ilike', 'ES_PRIORITY_TEST%')], limit=1
         )
 
     @patch('odoo.addons.som_crm.models.crm_lead.Client')

--- a/som_crm/tests/test_crm_lead_sync.py
+++ b/som_crm/tests/test_crm_lead_sync.py
@@ -189,7 +189,7 @@ class TestErpLeadSync(TransactionCase):
         self.assertIn(('crm_lead_id', '=', 0), call_domain)
         self.assertIn(('state', '=', 'done'), call_domain)
 
-
+    def test_get_contract_in_erp_priority(self):
         """
         Test the logic and search priority in 'get_contract_in_erp'.
         It should find by CUPS first, even if it has other data.


### PR DESCRIPTION
## Description
filter ERP lead matches by state=done before marking as won
https://freescout.somenergia.coop/conversation/8195332?folder_id=185


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Only match ERP leads with state='done' before linking and marking a CRM lead as won. Prevents winning leads based on ERP records that are still open.

- **Bug Fixes**
  - Added `('state', '=', 'done')` to ERP search domains in `get_contract_in_erp` and `_debug_erp_sync`.
  - Added tests to ensure only `state='done'` leads match and updated the CUPS-first priority test to include the state filter.

<sup>Written for commit 24a59e155a576e77838884f1a3296a3993dcfcb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/96?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR restricts ERP contract matching to finalized leads.
- Adds `state='done'` to production and diagnostic ERP search domains.
- Adds state-filter coverage and preserves the independently discovered CUPS-priority test.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the prior debug-domain mismatch and test-discovery issue are fixed at the current head.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_crm/models/crm_lead.py | Production and debug ERP matching now consistently require finalized ERP leads. |
| som_crm/tests/test_crm_lead_sync.py | Tests cover the finalized-state domain and retain the separate search-priority scenario. |

</details>

<sub>Reviews (3): Last reviewed commit: ["✅ Fix test"](https://github.com/som-energia/somenergia-odoo/commit/24a59e155a576e77838884f1a3296a3993dcfcb7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47925100)</sub>

<!-- /greptile_comment -->