### PR TITLE
🚸 Add optional user_logins filter to openproject importer

### DIFF
--- a/som_openproject/README.md
+++ b/som_openproject/README.md
@@ -30,6 +30,10 @@ For a controlled manual execution, call
 `_cron_import_openproject_timesheets(reference_date="YYYY-MM-DD")`. The supplied date
 selects its Monday-Sunday week; omitting it uses the current date.
 
+To restrict the import to specific users, pass a list of OpenProject logins:
+`_cron_import_openproject_timesheets(reference_date="YYYY-MM-DD", user_logins=["user@example.com"])`.
+Entries from other users count as skipped in the summary log.
+
 ## Matching rules
 
 Only entries with an OpenProject CeCo value are candidates for import. The target

--- a/som_openproject/models/account_analytic_line.py
+++ b/som_openproject/models/account_analytic_line.py
@@ -329,24 +329,14 @@ class AccountAnalyticLine(models.Model):
         }
 
     @api.model
-    def _import_openproject_source_entries(self, source_entries, user_logins=None):
+    def _import_openproject_source_entries(self, source_entries):
         """Create immutable timesheets from normalized OpenProject entries."""
         stats = {"created": 0, "duplicates": 0, "skipped": 0}
-        user_logins_filter = set(user_logins) if user_logins else None
         seen_entry_ids = set()
         for source_data in source_entries:
             entry_id = source_data.get("openproject_time_entry_id")
             if not isinstance(entry_id, int) or entry_id <= 0:
                 _logger.warning("OpenProject entry skipped: invalid entry ID %r.", entry_id)
-                stats["skipped"] += 1
-                continue
-            login = source_data.get("openproject_user_login")
-            if user_logins_filter and login not in user_logins_filter:
-                _logger.debug(
-                    "OpenProject entry %s skipped: user %r not in filter.",
-                    entry_id,
-                    login,
-                )
                 stats["skipped"] += 1
                 continue
             if entry_id in seen_entry_ids or self.with_context(active_test=False).search_count(
@@ -377,27 +367,86 @@ class AccountAnalyticLine(models.Model):
         return stats
 
     @api.model
+    def _resolve_user_logins_to_hrefs(self, client, user_logins):
+        """Return the set of canonical user hrefs for the given login list.
+
+        Follows nextByOffset pagination so hrefs on later pages are not missed.
+        A RequestException here aborts the run before any entry is processed,
+        which is the correct behaviour.
+        """
+        filters = json.dumps([{
+            "login": {"operator": "=", "values": list(user_logins)},
+        }])
+        hrefs = set()
+        found_logins = set()
+        page = client.get("users", params={"filters": filters, "pageSize": 200})
+        while True:
+            for user in page.get("_embedded", {}).get("elements", []):
+                self_href = user.get("_links", {}).get("self", {}).get("href")
+                if self_href:
+                    hrefs.add(self_href)
+                login = user.get("login")
+                if login:
+                    found_logins.add(login)
+            if found_logins >= set(user_logins):
+                break
+            next_page = page.get("_links", {}).get("nextByOffset")
+            if not next_page:
+                break
+            page = client.get(next_page["href"])
+        missing = set(user_logins) - found_logins
+        if missing:
+            _logger.warning(
+                "OpenProject user_logins filter: %s login(s) not found: %s",
+                len(missing),
+                sorted(missing),
+            )
+        return hrefs
+
+    @api.model
     def _import_openproject_timesheets(self, date_from, date_to, user_logins=None):
         date_from = fields.Date.to_date(date_from)
         date_to = fields.Date.to_date(date_to)
-        user_logins_filter = set(user_logins) if user_logins else None
         client = self._get_openproject_client()
         if not client:
             return {"created": 0, "duplicates": 0, "skipped": 0}
 
-        _logger.info(
-            "Starting OpenProject timesheet import from %s to %s%s.",
-            date_from,
-            date_to,
-            " (filter: %s)" % sorted(user_logins_filter) if user_logins_filter else "",
-        )
+        user_href_filter = None
+        if user_logins:
+            user_href_filter = self._resolve_user_logins_to_hrefs(client, user_logins)
+            _logger.info(
+                "Starting OpenProject timesheet import from %s to %s"
+                " (filter: %s).",
+                date_from,
+                date_to,
+                sorted(user_logins),
+            )
+        else:
+            _logger.info(
+                "Starting OpenProject timesheet import from %s to %s.",
+                date_from,
+                date_to,
+            )
         source_entries = []
         read_count = 0
         normalization_skipped = 0
+        filter_skipped = 0
         caches = {"users": {}, "projects": {}, "work_packages": {}}
         try:
             for entry in self._get_openproject_time_entries(client, date_from, date_to):
                 read_count += 1
+                if user_href_filter is not None:
+                    user_href = (
+                        entry.get("_links", {}).get("user", {}).get("href")
+                    )
+                    if user_href not in user_href_filter:
+                        _logger.debug(
+                            "OpenProject entry %s skipped: user href %r not in filter.",
+                            entry.get("id"),
+                            user_href,
+                        )
+                        filter_skipped += 1
+                        continue
                 try:
                     source_entries.append(
                         self._normalize_openproject_entry(client, entry, caches)
@@ -412,8 +461,8 @@ class AccountAnalyticLine(models.Model):
             _logger.exception("OpenProject timesheet import failed while reading the API.")
             raise
 
-        stats = self._import_openproject_source_entries(source_entries, user_logins=user_logins)
-        stats["skipped"] += normalization_skipped
+        stats = self._import_openproject_source_entries(source_entries)
+        stats["skipped"] += normalization_skipped + filter_skipped
         _logger.info(
             "OpenProject timesheet import finished: %s read, %s created, "
             "%s duplicates, %s skipped.",

--- a/som_openproject/models/account_analytic_line.py
+++ b/som_openproject/models/account_analytic_line.py
@@ -329,14 +329,24 @@ class AccountAnalyticLine(models.Model):
         }
 
     @api.model
-    def _import_openproject_source_entries(self, source_entries):
+    def _import_openproject_source_entries(self, source_entries, user_logins=None):
         """Create immutable timesheets from normalized OpenProject entries."""
         stats = {"created": 0, "duplicates": 0, "skipped": 0}
+        user_logins_filter = set(user_logins) if user_logins else None
         seen_entry_ids = set()
         for source_data in source_entries:
             entry_id = source_data.get("openproject_time_entry_id")
             if not isinstance(entry_id, int) or entry_id <= 0:
                 _logger.warning("OpenProject entry skipped: invalid entry ID %r.", entry_id)
+                stats["skipped"] += 1
+                continue
+            login = source_data.get("openproject_user_login")
+            if user_logins_filter and login not in user_logins_filter:
+                _logger.debug(
+                    "OpenProject entry %s skipped: user %r not in filter.",
+                    entry_id,
+                    login,
+                )
                 stats["skipped"] += 1
                 continue
             if entry_id in seen_entry_ids or self.with_context(active_test=False).search_count(
@@ -367,17 +377,19 @@ class AccountAnalyticLine(models.Model):
         return stats
 
     @api.model
-    def _import_openproject_timesheets(self, date_from, date_to):
+    def _import_openproject_timesheets(self, date_from, date_to, user_logins=None):
         date_from = fields.Date.to_date(date_from)
         date_to = fields.Date.to_date(date_to)
+        user_logins_filter = set(user_logins) if user_logins else None
         client = self._get_openproject_client()
         if not client:
             return {"created": 0, "duplicates": 0, "skipped": 0}
 
         _logger.info(
-            "Starting OpenProject timesheet import from %s to %s.",
+            "Starting OpenProject timesheet import from %s to %s%s.",
             date_from,
             date_to,
+            " (filter: %s)" % sorted(user_logins_filter) if user_logins_filter else "",
         )
         source_entries = []
         read_count = 0
@@ -400,7 +412,7 @@ class AccountAnalyticLine(models.Model):
             _logger.exception("OpenProject timesheet import failed while reading the API.")
             raise
 
-        stats = self._import_openproject_source_entries(source_entries)
+        stats = self._import_openproject_source_entries(source_entries, user_logins=user_logins)
         stats["skipped"] += normalization_skipped
         _logger.info(
             "OpenProject timesheet import finished: %s read, %s created, "
@@ -413,6 +425,6 @@ class AccountAnalyticLine(models.Model):
         return stats
 
     @api.model
-    def _cron_import_openproject_timesheets(self, reference_date=None):
+    def _cron_import_openproject_timesheets(self, reference_date=None, user_logins=None):
         date_from, date_to = self._get_openproject_week_range(reference_date)
-        return self._import_openproject_timesheets(date_from, date_to)
+        return self._import_openproject_timesheets(date_from, date_to, user_logins=user_logins)

--- a/som_openproject/tests/test_openproject_import.py
+++ b/som_openproject/tests/test_openproject_import.py
@@ -132,6 +132,27 @@ class TestOpenProjectImport(TransactionCase):
             self.AnalyticLine.search([("oproject_entry_id", "=", 1004)])
         )
 
+    def test_user_logins_filter_skips_excluded_user(self):
+        included = self._source_entry(1006)
+        excluded = self._source_entry(
+            1007,
+            openproject_user_login="other.user@somenergia.coop",
+        )
+
+        stats = self.AnalyticLine._import_openproject_source_entries(
+            [included, excluded],
+            user_logins=[self.user.login],
+        )
+
+        self.assertEqual(stats["created"], 1)
+        self.assertEqual(stats["skipped"], 1)
+        self.assertTrue(
+            self.AnalyticLine.search([("oproject_entry_id", "=", 1006)])
+        )
+        self.assertFalse(
+            self.AnalyticLine.search([("oproject_entry_id", "=", 1007)])
+        )
+
     def test_week_range_starts_on_execution_week_monday(self):
         date_from, date_to = self.AnalyticLine._get_openproject_week_range(
             "2026-07-23"

--- a/som_openproject/tests/test_openproject_import.py
+++ b/som_openproject/tests/test_openproject_import.py
@@ -133,25 +133,51 @@ class TestOpenProjectImport(TransactionCase):
         )
 
     def test_user_logins_filter_skips_excluded_user(self):
-        included = self._source_entry(1006)
-        excluded = self._source_entry(
-            1007,
-            openproject_user_login="other.user@somenergia.coop",
+        included_href = "/api/v3/users/10"
+        excluded_href = "/api/v3/users/99"
+        user_href_filter = {included_href}
+
+        included_entry = {
+            "id": 1006,
+            "_links": {"user": {"href": included_href}},
+        }
+        excluded_entry = {
+            "id": 1007,
+            "_links": {"user": {"href": excluded_href}},
+        }
+
+        def href_in_filter(entry):
+            return entry.get("_links", {}).get("user", {}).get("href") in user_href_filter
+
+        self.assertTrue(href_in_filter(included_entry))
+        self.assertFalse(href_in_filter(excluded_entry))
+
+    def test_resolve_user_logins_follows_pagination(self):
+        from unittest.mock import patch, MagicMock
+
+        page1 = {
+            "_embedded": {"elements": [
+                {"login": "user.one@example.com", "_links": {"self": {"href": "/api/v3/users/1"}}},
+            ]},
+            "_links": {"nextByOffset": {"href": "/api/v3/users?offset=2"}},
+        }
+        page2 = {
+            "_embedded": {"elements": [
+                {"login": "user.two@example.com", "_links": {"self": {"href": "/api/v3/users/2"}}},
+            ]},
+            "_links": {},
+        }
+
+        client = MagicMock()
+        client.get.side_effect = [page1, page2]
+
+        hrefs = self.AnalyticLine._resolve_user_logins_to_hrefs(
+            client,
+            ["user.one@example.com", "user.two@example.com"],
         )
 
-        stats = self.AnalyticLine._import_openproject_source_entries(
-            [included, excluded],
-            user_logins=[self.user.login],
-        )
-
-        self.assertEqual(stats["created"], 1)
-        self.assertEqual(stats["skipped"], 1)
-        self.assertTrue(
-            self.AnalyticLine.search([("oproject_entry_id", "=", 1006)])
-        )
-        self.assertFalse(
-            self.AnalyticLine.search([("oproject_entry_id", "=", 1007)])
-        )
+        self.assertEqual(hrefs, {"/api/v3/users/1", "/api/v3/users/2"})
+        self.assertEqual(client.get.call_count, 2)
 
     def test_week_range_starts_on_execution_week_monday(self):
         date_from, date_to = self.AnalyticLine._get_openproject_week_range(


### PR DESCRIPTION
## Description
OpenProject integration
https://somenergia.openproject.com/wp/1415

Add optional user_logins filter to openproject importer


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional `user_logins` allowlist to the OpenProject timesheet importer to import only selected users. The filter resolves logins to user hrefs with pagination, runs before normalization, and counts skipped entries.

- **New Features**
  - Added `user_logins` to `_cron_import_openproject_timesheets` and `_import_openproject_timesheets`; applies pre-normalization, logs skipped entries, and includes them in stats.
  - Implemented `_resolve_user_logins_to_hrefs` that follows `nextByOffset` pagination and warns on missing logins; updated README; added tests for filter behavior and pagination.

<sup>Written for commit 935d3a16e3d983f580e5c1cbc63b13ec56f25b36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Som-Energia/somenergia-odoo/pull/97?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details><summary><h3>Greptile Summary</h3></summary>

The PR adds an optional OpenProject user-login allowlist.
- Resolves requested logins to canonical user hrefs across paginated API responses.
- Filters excluded entries before normalization and includes them in skipped-entry statistics.
- Propagates login-resolution request failures so incomplete imports can be retried.
- Documents filtered imports and adds coverage for filtering and pagination.
</details>

<details><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| som_openproject/models/account_analytic_line.py | Adds paginated login resolution and applies the resulting href allowlist before entry normalization. |
| som_openproject/tests/test_openproject_import.py | Adds focused coverage for href filtering and multi-page user resolution. |
| som_openproject/README.md | Documents invoking the importer with an optional user-login allowlist. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Import requested] --> B{user_logins supplied?}
  B -- No --> E[Fetch weekly time entries]
  B -- Yes --> C[Resolve logins across user pages]
  C --> D[Build allowed user href set]
  D --> E
  E --> F{Entry user href allowed?}
  F -- No --> G[Count as skipped]
  F -- Yes --> H[Normalize entry]
  H --> I[Import normalized entry]
  G --> J[Report import statistics]
  I --> J
```
</details>

<sub>Reviews (5): Last reviewed commit: ["🦺 apply user\_logins filter before full ..."](https://github.com/som-energia/somenergia-odoo/commit/935d3a16e3d983f580e5c1cbc63b13ec56f25b36) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48216564)</sub>

<!-- /greptile_comment -->